### PR TITLE
NFC Magic: try the per-UID key cache before the dictionary attack

### DIFF
--- a/base_pack/nfc_magic/CHANGELOG.md
+++ b/base_pack/nfc_magic/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.1
+
+### Added
+
+- **MIFARE Classic key cache phase** - the dictionary attack now tries the NFC app's per-UID key
+  cache (`/ext/nfc/.cache/<UID>.keys`) before the user and system dictionaries, for both **Write**
+  and **Wipe**. A magic clone carries the original card's UID, so keys the NFC app recovered when
+  the original was saved are already on the SD card under the clone's own name. They are fed to
+  the poller as a dictionary, so each one is still authenticated against the card in front of you;
+  a stale entry costs a few failed auths and nothing more. When the cache alone finishes the card,
+  the two dictionary phases are skipped instead of being run for nothing. A card with no cache
+  entry runs exactly as before.
+
+### Fixed
+
+- **Wiping a Gen2 clone of a static-encrypted-nonce card (FM11RF08S)** dead-ended at
+  **"No keys found"**. Those keys only ever reach the per-UID dictionary, so neither shared
+  dictionary has them; the key cache phase now does.
+
 ## 2.0
 
 Major release. Adds magic **Ultralight / NTAG (USCUID-UL)** support, and reworks the magic

--- a/base_pack/nfc_magic/application.fam
+++ b/base_pack/nfc_magic/application.fam
@@ -10,7 +10,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="Application for writing to NFC tags with modifiable sector 0",
-    fap_version="2.0",
+    fap_version="2.1",
     fap_icon="assets/Nfc_10px.png",
     fap_category="NFC",
     fap_icon_assets="assets",

--- a/base_pack/nfc_magic/helpers/mfc_key_cache.c
+++ b/base_pack/nfc_magic/helpers/mfc_key_cache.c
@@ -1,0 +1,142 @@
+#include "mfc_key_cache.h"
+
+#include <furi/furi.h>
+#include <flipper_format/flipper_format.h>
+
+#define TAG "MfcKeyCache"
+
+#define MFC_KEY_CACHE_FOLDER    "/ext/nfc/.cache"
+#define MFC_KEY_CACHE_EXTENSION ".keys"
+
+// Must match applications/main/nfc/helpers/mf_classic_key_cache.c in the firmware.
+static const char* mfc_key_cache_file_header = "Flipper NFC keys";
+static const uint32_t mfc_key_cache_file_version = 1;
+
+// The firmware's own cache holder wraps this same SDK type. A map bit below
+// MF_CLASSIC_TOTAL_SECTORS_MAX set = that sector's key is loaded; the file's maps are 64-bit, so
+// any higher bit addresses no key slot and is never loaded, served, or counted.
+struct MfcKeyCache {
+    MfClassicDeviceKeys keys;
+};
+
+static void mfc_key_cache_get_file_path(const uint8_t* uid, size_t uid_len, FuriString* path) {
+    furi_string_printf(path, "%s/", MFC_KEY_CACHE_FOLDER);
+    for(size_t i = 0; i < uid_len; i++) {
+        furi_string_cat_printf(path, "%02X", uid[i]);
+    }
+    furi_string_cat_str(path, MFC_KEY_CACHE_EXTENSION);
+}
+
+static size_t mfc_key_cache_count_keys(const MfcKeyCache* instance) {
+    size_t total_keys = 0;
+    for(uint8_t i = 0; i < MF_CLASSIC_TOTAL_SECTORS_MAX; i++) {
+        total_keys +=
+            FURI_BIT(instance->keys.key_a_mask, i) + FURI_BIT(instance->keys.key_b_mask, i);
+    }
+
+    return total_keys;
+}
+
+static bool mfc_key_cache_read(MfcKeyCache* instance, FlipperFormat* ff, FuriString* temp_str) {
+    uint32_t version = 0;
+    if(!flipper_format_read_header(ff, temp_str, &version)) return false;
+    if(furi_string_cmp_str(temp_str, mfc_key_cache_file_header) != 0) return false;
+    if(version != mfc_key_cache_file_version) return false;
+
+    // flipper_format only ever scans forward, so the maps and then the keys have to be read in the
+    // order the writer emitted them: both maps, then each sector ascending, A before B. The
+    // informational "Mifare Classic type" line the writer puts between the header and the maps has
+    // no reader here; the forward scan for "Key A map" simply passes over it.
+    if(!flipper_format_read_hex_uint64(ff, "Key A map", &instance->keys.key_a_mask, 1))
+        return false;
+    if(!flipper_format_read_hex_uint64(ff, "Key B map", &instance->keys.key_b_mask, 1))
+        return false;
+
+    for(uint8_t i = 0; i < MF_CLASSIC_TOTAL_SECTORS_MAX; i++) {
+        if(FURI_BIT(instance->keys.key_a_mask, i)) {
+            furi_string_printf(temp_str, "Key A sector %d", i);
+            if(!flipper_format_read_hex(
+                   ff,
+                   furi_string_get_cstr(temp_str),
+                   instance->keys.key_a[i].data,
+                   sizeof(MfClassicKey)))
+                return false;
+        }
+        if(FURI_BIT(instance->keys.key_b_mask, i)) {
+            furi_string_printf(temp_str, "Key B sector %d", i);
+            if(!flipper_format_read_hex(
+                   ff,
+                   furi_string_get_cstr(temp_str),
+                   instance->keys.key_b[i].data,
+                   sizeof(MfClassicKey)))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+MfcKeyCache* mfc_key_cache_load(Storage* storage, const uint8_t* uid, size_t uid_len) {
+    furi_assert(storage);
+    furi_assert(uid);
+
+    // No UID names no entry, and an empty one would resolve to the openable path ".../.keys".
+    if(uid_len == 0) return NULL;
+
+    FuriString* file_path = furi_string_alloc();
+    mfc_key_cache_get_file_path(uid, uid_len, file_path);
+
+    FlipperFormat* ff = flipper_format_buffered_file_alloc(storage);
+    FuriString* temp_str = furi_string_alloc();
+    MfcKeyCache* instance = malloc(sizeof(MfcKeyCache));
+
+    // Most cards were never saved in the NFC app, so no entry at all is the ordinary outcome.
+    const bool file_opened =
+        flipper_format_buffered_file_open_existing(ff, furi_string_get_cstr(file_path));
+    // A truncated file leaves map bits set for keys that were never read, so anything short of a
+    // complete parse is discarded rather than handed back with zeroed keys in the gaps.
+    const bool loaded = file_opened && mfc_key_cache_read(instance, ff, temp_str) &&
+                        (mfc_key_cache_count_keys(instance) > 0);
+
+    if(!loaded) {
+        mfc_key_cache_free(instance);
+        instance = NULL;
+        // A card with no entry is expected and stays quiet. An entry that exists but was rejected
+        // is indistinguishable from it on screen, and the fix -- re-save the card in the NFC app,
+        // or a firmware that bumped the format version -- is unguessable without this line.
+        if(file_opened) {
+            FURI_LOG_W(TAG, "%s unusable, skipping", furi_string_get_cstr(file_path));
+        }
+    }
+
+    flipper_format_buffered_file_close(ff);
+    flipper_format_free(ff);
+    furi_string_free(temp_str);
+    furi_string_free(file_path);
+
+    return instance;
+}
+
+void mfc_key_cache_free(MfcKeyCache* instance) {
+    furi_assert(instance);
+
+    free(instance);
+}
+
+bool mfc_key_cache_get_key(
+    const MfcKeyCache* instance,
+    uint8_t sector,
+    MfClassicKeyType key_type,
+    MfClassicKey* key) {
+    furi_assert(instance);
+    furi_assert(key);
+
+    if(sector >= MF_CLASSIC_TOTAL_SECTORS_MAX) return false;
+
+    const bool is_key_a = (key_type == MfClassicKeyTypeA);
+    const uint64_t mask = is_key_a ? instance->keys.key_a_mask : instance->keys.key_b_mask;
+    if(!FURI_BIT(mask, sector)) return false;
+
+    *key = is_key_a ? instance->keys.key_a[sector] : instance->keys.key_b[sector];
+    return true;
+}

--- a/base_pack/nfc_magic/helpers/mfc_key_cache.h
+++ b/base_pack/nfc_magic/helpers/mfc_key_cache.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <nfc/protocols/mf_classic/mf_classic.h>
+#include <storage/storage.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Read-only twin of the NFC app's /ext/nfc/.cache/<UID>.keys reader. Saving a card in the NFC app
+// writes every key it recovered there under the card's UID -- including the keys of a static
+// encrypted nonce tag, which MFKey32 only ever puts in the per-UID (CUID) dictionary. A magic
+// clone carries that same UID, so the entry is the clone's keys too. The firmware's own reader is
+// internal to the NFC app and not exported through the API, hence this local copy; it never
+// writes, so it cannot corrupt an entry the NFC app owns.
+typedef struct MfcKeyCache MfcKeyCache;
+
+/** Load the entry named by uid. Returns NULL, having allocated nothing the caller must release,
+ * when uid_len is 0, there is no entry, the header or version doesn't match, a key one of the maps
+ * promises isn't in the file, or the entry holds no keys at all. A half-parsed entry is never
+ * returned, so a non-NULL result always has at least one key that came out of the file. */
+MfcKeyCache* mfc_key_cache_load(Storage* storage, const uint8_t* uid, size_t uid_len);
+
+void mfc_key_cache_free(MfcKeyCache* instance);
+
+/** Read one key. Returns false when the entry holds no key of that type for that sector. */
+bool mfc_key_cache_get_key(
+    const MfcKeyCache* instance,
+    uint8_t sector,
+    MfClassicKeyType key_type,
+    MfClassicKey* key);
+
+#ifdef __cplusplus
+}
+#endif

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.c
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.c
@@ -27,6 +27,8 @@ struct NfcMagicScanner {
     Gen4* gen4_data;
     Gen2Type gen2_type;
     uint8_t gen1_uid_len;
+    uint8_t uid[ISO14443_3A_MAX_UID_SIZE];
+    uint8_t uid_len;
     UscuidUlData uscuid_ul_data;
 
     NfcMagicScannerCallback callback;
@@ -45,6 +47,8 @@ static void nfc_magic_scanner_reset(NfcMagicScanner* instance) {
     instance->session_state = NfcMagicScannerSessionStateIdle;
     instance->gen2_type = Gen2TypeUnknown;
     instance->gen1_uid_len = 0;
+    memset(instance->uid, 0, sizeof(instance->uid));
+    instance->uid_len = 0;
     memset(&instance->uscuid_ul_data, 0, sizeof(UscuidUlData));
 }
 
@@ -75,13 +79,14 @@ void nfc_magic_scanner_set_gen4_password(NfcMagicScanner* instance, Gen4Password
 
 // One ISO14443-3A identity read via a standard activation. SAK splits the magic families
 // (Ultralight/NTAG answer SAK 0x00, MIFARE Classic does not) BEFORE any backdoor frame,
-// and the UID length (4/7) tells 4- vs 7-byte Gen1 tags apart (the wakeup is UID-agnostic).
+// the UID length (4/7) tells 4- vs 7-byte Gen1 tags apart (the wakeup is UID-agnostic), and
+// the UID itself names the NFC app's per-UID key cache entry, which a magic clone inherits
+// from the card it was cloned from.
 typedef struct {
     bool activated;
     uint8_t sak;
-    uint8_t uid_len; // 4 or 7, else 0 ("unknown")
-    uint8_t uid0; // first two UID bytes, for the unpersonalized UL-5 (AA 55) heuristic
-    uint8_t uid1;
+    uint8_t uid[ISO14443_3A_MAX_UID_SIZE];
+    uint8_t uid_len; // Bytes valid in uid; 0 when not activated
 } NfcMagicScannerIdentity;
 
 static NfcMagicScannerIdentity nfc_magic_scanner_read_identity(Nfc* nfc) {
@@ -92,11 +97,8 @@ static NfcMagicScannerIdentity nfc_magic_scanner_read_identity(Nfc* nfc) {
         const Iso14443_3aData* data = nfc_poller_get_data(poller);
         id.activated = true;
         id.sak = data->sak;
-        id.uid_len = (data->uid_len == 4 || data->uid_len == 7) ? data->uid_len : 0;
-        if(data->uid_len >= 2) {
-            id.uid0 = data->uid[0];
-            id.uid1 = data->uid[1];
-        }
+        id.uid_len = MIN(data->uid_len, (uint8_t)sizeof(id.uid));
+        memcpy(id.uid, data->uid, id.uid_len);
     }
     nfc_poller_free(poller);
 
@@ -138,6 +140,8 @@ static bool nfc_magic_scanner_detect_not_magic(Nfc* nfc) {
 // answers the same 40/43 wakeup as a Gen1A) from being misdetected as Gen1.
 static bool nfc_magic_scanner_detect_pass(NfcMagicScanner* instance, NfcMagicProtocol* protocol) {
     const NfcMagicScannerIdentity id = nfc_magic_scanner_read_identity(instance->nfc);
+    memcpy(instance->uid, id.uid, sizeof(instance->uid));
+    instance->uid_len = id.uid_len;
 
     // Gen4 (UMC) is family-agnostic and definitive; probe it first so a wiped UMC isn't
     // mistaken for a Gen2 CUID or a blank Ultralight.
@@ -155,7 +159,7 @@ static bool nfc_magic_scanner_detect_pass(NfcMagicScanner* instance, NfcMagicPro
         }
         // Unpersonalized UL-5 has a locked config (so the probe above fails) but is
         // identifiable by its UID prefix AA 55. Report it as a detect-only hint.
-        if(id.uid0 == 0xAA && id.uid1 == 0x55) {
+        if(id.uid_len >= 2 && id.uid[0] == 0xAA && id.uid[1] == 0x55) {
             memset(&instance->uscuid_ul_data, 0, sizeof(UscuidUlData));
             instance->uscuid_ul_data.maybe_ul5 = true;
             *protocol = NfcMagicProtocolUscuidUl;
@@ -171,7 +175,11 @@ static bool nfc_magic_scanner_detect_pass(NfcMagicScanner* instance, NfcMagicPro
     } else if(id.activated) {
         // MIFARE Classic family.
         if(gen1a_poller_detect(instance->nfc)) {
-            instance->gen1_uid_len = id.uid_len;
+            // Gen1 only knows the two standard Classic UID lengths; anything else is "unknown".
+            instance->gen1_uid_len =
+                (id.uid_len == ISO14443_3A_UID_4_BYTES || id.uid_len == ISO14443_3A_UID_7_BYTES) ?
+                    id.uid_len :
+                    0;
             *protocol = NfcMagicProtocolGen1;
             return true;
         }
@@ -216,7 +224,9 @@ static int32_t nfc_magic_scanner_worker(void* context) {
                 .data.gen2_type = instance->gen2_type,
                 .data.gen1_uid_len = instance->gen1_uid_len,
                 .data.uscuid_ul = instance->uscuid_ul_data,
+                .data.uid_len = instance->uid_len,
             };
+            memcpy(event.data.uid, instance->uid, sizeof(event.data.uid));
             instance->callback(event, instance->context);
             break;
         }

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.h
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.h
@@ -2,6 +2,7 @@
 
 #include "protocols/gen4/gen4.h"
 #include <nfc/nfc.h>
+#include <nfc/protocols/iso14443_3a/iso14443_3a.h>
 #include "protocols/nfc_magic_protocols.h"
 #include "protocols/gen2/gen2_poller.h"
 #include "protocols/uscuid_ul/uscuid_ul_poller.h"
@@ -19,8 +20,10 @@ typedef enum {
 typedef struct {
     NfcMagicProtocol protocol;
     Gen2Type gen2_type; // Valid when protocol == NfcMagicProtocolGen2
-    uint8_t gen1_uid_len; // Gen1 UID length (4/7) when resolved; 0 if unknown or not Gen1
+    uint8_t gen1_uid_len; // Gen1 UID length class (4/7) derived from uid_len; 0 if not Gen1
     UscuidUlData uscuid_ul; // Valid when protocol == NfcMagicProtocolUscuidUl
+    uint8_t uid[ISO14443_3A_MAX_UID_SIZE]; // UID from the standard activation
+    uint8_t uid_len; // Bytes valid in uid; 0 when the card never activated (backdoor-only)
 } NfcMagicScannerEventData;
 
 typedef struct {

--- a/base_pack/nfc_magic/nfc_magic_app.c
+++ b/base_pack/nfc_magic/nfc_magic_app.c
@@ -207,6 +207,23 @@ void nfc_magic_app_free(NfcMagicApp* instance) {
     free(instance);
 }
 
+// The dict attack owns exactly one key source at a time: a KeysDict for a dictionary phase, a
+// MfcKeyCache for the key cache phase. Freeing through here and dropping the pointer keeps every
+// exit path -- the phase chain, the scene's on_exit, a write-check back-out -- from freeing the
+// same one twice.
+void nfc_magic_app_free_dict_attack_keys(NfcMagicApp* instance) {
+    furi_assert(instance);
+
+    if(instance->nfc_dict_context.dict) {
+        keys_dict_free(instance->nfc_dict_context.dict);
+        instance->nfc_dict_context.dict = NULL;
+    }
+    if(instance->nfc_dict_context.key_cache) {
+        mfc_key_cache_free(instance->nfc_dict_context.key_cache);
+        instance->nfc_dict_context.key_cache = NULL;
+    }
+}
+
 static const NotificationSequence nfc_magic_sequence_blink_start_cyan = {
     &message_blink_start_10,
     &message_blink_set_color_cyan,

--- a/base_pack/nfc_magic/nfc_magic_app_i.h
+++ b/base_pack/nfc_magic/nfc_magic_app_i.h
@@ -2,6 +2,7 @@
 
 #include "nfc_magic_app.h"
 #include "helpers/nfc_magic_custom_events.h"
+#include "helpers/mfc_key_cache.h"
 
 #include <furi.h>
 #include <gui/gui.h>
@@ -73,7 +74,10 @@ enum NfcMagicAppCustomEvent {
 };
 
 typedef struct {
-    KeysDict* dict;
+    KeysDict* dict; // dictionary phases; NULL while the key cache phase runs
+    MfcKeyCache* key_cache; // key cache phase only; NULL selects the dictionary above. Mirrors the
+        // scene state -- prepare_view is the only place both are set
+    uint8_t cache_key_index; // cache cursor within current_sector: 0 = key A, 1 = key B
     uint8_t sectors_total;
     uint8_t sectors_read;
     uint8_t current_sector;
@@ -173,6 +177,8 @@ typedef enum {
     NfcMagicAppViewDictAttack,
     NfcMagicAppViewWriteProblems,
 } NfcMagicAppView;
+
+void nfc_magic_app_free_dict_attack_keys(NfcMagicApp* instance);
 
 void nfc_magic_app_blink_start(NfcMagicApp* nfc_magic);
 

--- a/base_pack/nfc_magic/nfc_magic_app_i.h
+++ b/base_pack/nfc_magic/nfc_magic_app_i.h
@@ -116,7 +116,9 @@ struct NfcMagicApp {
     Nfc* nfc;
     NfcMagicProtocol protocol;
     Gen2Type gen2_type;
-    uint8_t gen1_uid_len;
+    uint8_t gen1_uid_len; // Gen1 UID length class (4/7) derived from card_uid_len; 0 if not Gen1
+    uint8_t card_uid[ISO14443_3A_MAX_UID_SIZE]; // scanned card's UID; names its key cache entry
+    uint8_t card_uid_len; // 0 when the card never activated (backdoor-only)
     UscuidUlData uscuid_ul_data;
     uint16_t write_progress_current; // USCUID-UL: pages written so far (live progress)
     uint16_t write_progress_total; // USCUID-UL: total pages to write

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_check.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_check.c
@@ -10,6 +10,8 @@ void nfc_magic_check_worker_callback(NfcMagicScannerEvent event, void* context) 
         instance->gen2_type = event.data.gen2_type;
         instance->gen1_uid_len = event.data.gen1_uid_len;
         instance->uscuid_ul_data = event.data.uscuid_ul;
+        memcpy(instance->card_uid, event.data.uid, sizeof(instance->card_uid));
+        instance->card_uid_len = event.data.uid_len;
         view_dispatcher_send_custom_event(
             instance->view_dispatcher, NfcMagicCustomEventWorkerSuccess);
     } else if(event.type == NfcMagicScannerEventTypeDetectedNotMagic) {

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_gen2_write_check.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_gen2_write_check.c
@@ -86,12 +86,10 @@ void nfc_magic_scene_gen2_write_check_on_exit(void* context) {
     instance->write_problems_context.problems.all_problems = 0;
 
     // Backing out to the menu pops the dict-attack scene WITHOUT running its on_exit (the scene
-    // manager only exits the current scene), so its KeysDict would leak. Free it here if still
-    // owned; dict-attack on_exit NULLs it on the forward path, so this won't double-free.
-    if(instance->nfc_dict_context.dict) {
-        keys_dict_free(instance->nfc_dict_context.dict);
-        instance->nfc_dict_context.dict = NULL;
-    }
+    // manager only exits the current scene), so its key source would leak. Free it here if still
+    // owned; dict-attack on_exit clears the pointers on the forward path, so this won't
+    // double-free.
+    nfc_magic_app_free_dict_attack_keys(instance);
 
     write_problems_reset(instance->write_problems);
 }

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_mf_classic_dict_attack.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_mf_classic_dict_attack.c
@@ -7,10 +7,48 @@
 
 #define TAG "NfcMagicMfClassicDictAttack"
 
+// The cache holds at most one key A and one key B per sector, so a sector is worth two tries.
+#define DICT_ATTACK_CACHE_KEYS_PER_SECTOR (2)
+
+// Declared in chain order: prepare_view walks it forwards, eliding any phase whose key source is
+// missing or empty, and on_event advances by one. Keep the order and the chain follows.
 typedef enum {
+    DictAttackStateKeyCacheInProgress,
     DictAttackStateUserDictInProgress,
     DictAttackStateSystemDictInProgress,
 } DictAttackState;
+
+// Key source for the phase in progress. The cache answers only for the sector the poller is on:
+// key A, then key B, then nothing, which is what moves the poller to the next sector. In this mode
+// NextSector is the poller's only sector move, and both the NextSector and DataUpdate handlers
+// carry that same poller field into current_sector, so it is the sector being asked about. Cached
+// keys go out through RequestKey rather than into target_dev precisely so the poller has to
+// authenticate with each one; see the on_enter comment below for what pre-found keys cost.
+static bool nfc_dict_attack_get_next_key(NfcMagicApp* instance, MfClassicKey* key) {
+    NfcMagicAppMfClassicDictAttackContext* dict_ctx = &instance->nfc_dict_context;
+
+    if(dict_ctx->key_cache == NULL) {
+        return keys_dict_get_next_key(dict_ctx->dict, key->data, sizeof(MfClassicKey));
+    }
+
+    while(dict_ctx->cache_key_index < DICT_ATTACK_CACHE_KEYS_PER_SECTOR) {
+        const bool serve_key_a = (dict_ctx->cache_key_index++ == 0);
+        const MfClassicKeyType key_type = serve_key_a ? MfClassicKeyTypeA : MfClassicKeyTypeB;
+        if(mfc_key_cache_get_key(dict_ctx->key_cache, dict_ctx->current_sector, key_type, key)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// A dictionary is walked from the top for every sector and every key-attack return, so it gets
+// rewound at both. The cache cursor is not: see the NextSector handler.
+static void nfc_dict_attack_rewind_dict(NfcMagicApp* instance) {
+    if(instance->nfc_dict_context.dict != NULL) {
+        keys_dict_rewind(instance->nfc_dict_context.dict);
+    }
+}
 
 NfcCommand nfc_dict_attack_worker_callback(NfcGenericEvent event, void* context) {
     furi_assert(context);
@@ -55,8 +93,7 @@ NfcCommand nfc_dict_attack_worker_callback(NfcGenericEvent event, void* context)
             instance->view_dispatcher, NfcMagicAppCustomEventDictAttackDataUpdate);
     } else if(mfc_event->type == MfClassicPollerEventTypeRequestKey) {
         MfClassicKey key = {};
-        if(keys_dict_get_next_key(
-               instance->nfc_dict_context.dict, key.data, sizeof(MfClassicKey))) {
+        if(nfc_dict_attack_get_next_key(instance, &key)) {
             mfc_event->data->key_request_data.key = key;
             mfc_event->data->key_request_data.key_provided = true;
             instance->nfc_dict_context.dict_keys_current++;
@@ -75,7 +112,11 @@ NfcCommand nfc_dict_attack_worker_callback(NfcGenericEvent event, void* context)
         view_dispatcher_send_custom_event(
             instance->view_dispatcher, NfcMagicAppCustomEventDictAttackDataUpdate);
     } else if(mfc_event->type == MfClassicPollerEventTypeNextSector) {
-        keys_dict_rewind(instance->nfc_dict_context.dict);
+        nfc_dict_attack_rewind_dict(instance);
+        // The cache cursor is per-sector, and this is the only event that moves the sector. A key
+        // attack returns the poller to the same one, so rewinding there would re-offer a key it
+        // already tried and buy one more failed auth (~10 ms of radio) per sector.
+        instance->nfc_dict_context.cache_key_index = 0;
         instance->nfc_dict_context.dict_keys_current = 0;
         instance->nfc_dict_context.current_sector =
             mfc_event->data->next_sector_data.current_sector;
@@ -94,7 +135,7 @@ NfcCommand nfc_dict_attack_worker_callback(NfcGenericEvent event, void* context)
         view_dispatcher_send_custom_event(
             instance->view_dispatcher, NfcMagicAppCustomEventDictAttackDataUpdate);
     } else if(mfc_event->type == MfClassicPollerEventTypeKeyAttackStop) {
-        keys_dict_rewind(instance->nfc_dict_context.dict);
+        nfc_dict_attack_rewind_dict(instance);
         instance->nfc_dict_context.is_key_attack = false;
         instance->nfc_dict_context.dict_keys_current = 0;
         view_dispatcher_send_custom_event(
@@ -138,6 +179,20 @@ static void nfc_magic_scene_mf_classic_dict_attack_update_view(NfcMagicApp* inst
 static void nfc_magic_scene_mf_classic_dict_attack_prepare_view(NfcMagicApp* instance) {
     uint32_t state =
         scene_manager_get_scene_state(instance->scene_manager, NfcMagicSceneMfClassicDictAttack);
+    if(state == DictAttackStateKeyCacheInProgress) {
+        // A magic clone carries the original's UID, so the NFC app's cache entry for the original
+        // is this card's keys as well -- and for a static encrypted nonce tag it is the only place
+        // they exist, since neither shared dictionary ever sees them. A miss skips the phase
+        // outright (no header, no poller pass), so a card that was never saved in the NFC app, and
+        // one that never activated and so has no UID at all, run exactly as they did before.
+        instance->nfc_dict_context.key_cache =
+            mfc_key_cache_load(instance->storage, instance->card_uid, instance->card_uid_len);
+        if(instance->nfc_dict_context.key_cache != NULL) {
+            dict_attack_set_header(instance->dict_attack, "MF Classic Key Cache");
+        } else {
+            state = DictAttackStateUserDictInProgress;
+        }
+    }
     if(state == DictAttackStateUserDictInProgress) {
         do {
             if(!keys_dict_check_presence(NFC_APP_MF_CLASSIC_DICT_USER_PATH)) {
@@ -162,11 +217,16 @@ static void nfc_magic_scene_mf_classic_dict_attack_prepare_view(NfcMagicApp* ins
         dict_attack_set_header(instance->dict_attack, "MF Classic System Dictionary");
     }
 
+    // The cache offers at most an A/B pair for the sector in hand, so the bar is fixed to that
+    // pair rather than to the length of a dictionary it doesn't have.
     instance->nfc_dict_context.dict_keys_total =
-        keys_dict_get_total_keys(instance->nfc_dict_context.dict);
+        (instance->nfc_dict_context.key_cache != NULL) ?
+            DICT_ATTACK_CACHE_KEYS_PER_SECTOR :
+            keys_dict_get_total_keys(instance->nfc_dict_context.dict);
     dict_attack_set_total_dict_keys(
         instance->dict_attack, instance->nfc_dict_context.dict_keys_total);
     instance->nfc_dict_context.dict_keys_current = 0;
+    instance->nfc_dict_context.cache_key_index = 0;
 
     dict_attack_set_callback(
         instance->dict_attack, nfc_dict_attack_dict_attack_result_callback, instance);
@@ -174,6 +234,28 @@ static void nfc_magic_scene_mf_classic_dict_attack_prepare_view(NfcMagicApp* ins
 
     scene_manager_set_scene_state(
         instance->scene_manager, NfcMagicSceneMfClassicDictAttack, state);
+
+    // The worker thread picks its key source off key_cache, on_event picks the phase off the
+    // scene state, and this is the only place both are written -- an early return here splits them.
+    furi_assert(
+        (instance->nfc_dict_context.key_cache != NULL) ==
+        (state == DictAttackStateKeyCacheInProgress));
+}
+
+// Hand the scene to the next phase. Each phase runs its own poller pass, and prepare_view drops
+// a phase whose key source is missing or empty, so the chain is key cache -> user dict -> system
+// dict with either of the first two elided.
+static void nfc_magic_scene_mf_classic_dict_attack_start_phase(
+    NfcMagicApp* instance,
+    DictAttackState next_state) {
+    nfc_poller_stop(instance->poller);
+    nfc_poller_free(instance->poller);
+    nfc_magic_app_free_dict_attack_keys(instance);
+    scene_manager_set_scene_state(
+        instance->scene_manager, NfcMagicSceneMfClassicDictAttack, next_state);
+    nfc_magic_scene_mf_classic_dict_attack_prepare_view(instance);
+    instance->poller = nfc_poller_alloc(instance->nfc, NfcProtocolMfClassic);
+    nfc_poller_start(instance->poller, nfc_dict_attack_worker_callback, instance);
 }
 
 void nfc_magic_scene_mf_classic_dict_attack_on_enter(void* context) {
@@ -181,14 +263,14 @@ void nfc_magic_scene_mf_classic_dict_attack_on_enter(void* context) {
 
     // Re-read the card fresh each op. The dict attack seeds the poller from target_dev and the
     // poller trusts pre-found keys (skips re-auth), so keys cached by a prior write/wipe would be
-    // replayed -- writing/wiping with the wrong keys. Runs once per op, so the user->system
-    // two-pass reuse below (target_dev carried between passes) is unaffected.
+    // replayed -- writing/wiping with the wrong keys. Runs once per op, so the phase chain's own
+    // reuse below (target_dev carried between passes) is unaffected.
     nfc_device_clear(instance->target_dev);
 
     scene_manager_set_scene_state(
         instance->scene_manager,
         NfcMagicSceneMfClassicDictAttack,
-        DictAttackStateUserDictInProgress);
+        DictAttackStateKeyCacheInProgress);
     nfc_magic_scene_mf_classic_dict_attack_prepare_view(instance);
     dict_attack_set_card_state(instance->dict_attack, true);
     view_dispatcher_switch_to_view(instance->view_dispatcher, NfcMagicAppViewDictAttack);
@@ -230,6 +312,22 @@ static void nfc_magic_scene_mf_classic_dict_attack_proceed_to_write(NfcMagicApp*
     }
 }
 
+// One statement of the chain: the enum's order is the phase order, and there is nothing left to
+// look for once every sector is read and both its keys are known. Stopping there matters because
+// each further phase restarts the poller and reloads its dictionary -- the system one is ~67 KB
+// read on this thread -- which a cache hit that finished the card would otherwise pay for twice.
+// Only the cache phase can finish a card outright, so the dictionary chain is unchanged.
+static void nfc_magic_scene_mf_classic_dict_attack_advance(NfcMagicApp* instance, uint32_t state) {
+    const bool card_read = (state == DictAttackStateKeyCacheInProgress) &&
+                           mf_classic_is_card_read(nfc_poller_get_data(instance->poller));
+
+    if(state == DictAttackStateSystemDictInProgress || card_read) {
+        nfc_magic_scene_mf_classic_dict_attack_proceed_to_write(instance);
+    } else {
+        nfc_magic_scene_mf_classic_dict_attack_start_phase(instance, (DictAttackState)(state + 1));
+    }
+}
+
 bool nfc_magic_scene_mf_classic_dict_attack_on_event(void* context, SceneManagerEvent event) {
     NfcMagicApp* instance = context;
     bool consumed = false;
@@ -238,22 +336,8 @@ bool nfc_magic_scene_mf_classic_dict_attack_on_event(void* context, SceneManager
         scene_manager_get_scene_state(instance->scene_manager, NfcMagicSceneMfClassicDictAttack);
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == NfcMagicAppCustomEventDictAttackComplete) {
-            if(state == DictAttackStateUserDictInProgress) {
-                nfc_poller_stop(instance->poller);
-                nfc_poller_free(instance->poller);
-                keys_dict_free(instance->nfc_dict_context.dict);
-                scene_manager_set_scene_state(
-                    instance->scene_manager,
-                    NfcMagicSceneMfClassicDictAttack,
-                    DictAttackStateSystemDictInProgress);
-                nfc_magic_scene_mf_classic_dict_attack_prepare_view(instance);
-                instance->poller = nfc_poller_alloc(instance->nfc, NfcProtocolMfClassic);
-                nfc_poller_start(instance->poller, nfc_dict_attack_worker_callback, instance);
-                consumed = true;
-            } else {
-                nfc_magic_scene_mf_classic_dict_attack_proceed_to_write(instance);
-                consumed = true;
-            }
+            nfc_magic_scene_mf_classic_dict_attack_advance(instance, state);
+            consumed = true;
         } else if(event.event == NfcMagicAppCustomEventCardDetected) {
             dict_attack_set_card_state(instance->dict_attack, true);
             consumed = true;
@@ -265,26 +349,14 @@ bool nfc_magic_scene_mf_classic_dict_attack_on_event(void* context, SceneManager
         } else if(event.event == NfcMagicAppCustomEventDictAttackSkip) {
             const MfClassicData* mfc_data = nfc_poller_get_data(instance->poller);
             nfc_device_set_data(instance->target_dev, NfcProtocolMfClassic, mfc_data);
-            if(state == DictAttackStateUserDictInProgress) {
-                if(instance->nfc_dict_context.is_card_present) {
-                    nfc_poller_stop(instance->poller);
-                    nfc_poller_free(instance->poller);
-                    keys_dict_free(instance->nfc_dict_context.dict);
-                    scene_manager_set_scene_state(
-                        instance->scene_manager,
-                        NfcMagicSceneMfClassicDictAttack,
-                        DictAttackStateSystemDictInProgress);
-                    nfc_magic_scene_mf_classic_dict_attack_prepare_view(instance);
-                    instance->poller = nfc_poller_alloc(instance->nfc, NfcProtocolMfClassic);
-                    nfc_poller_start(instance->poller, nfc_dict_attack_worker_callback, instance);
-                } else {
-                    nfc_magic_scene_mf_classic_dict_attack_proceed_to_write(instance);
-                }
-                consumed = true;
-            } else if(state == DictAttackStateSystemDictInProgress) {
+            // Skipping once the card is gone means the user is done, not that they want the
+            // next phase started on a card that isn't there.
+            if(instance->nfc_dict_context.is_card_present) {
+                nfc_magic_scene_mf_classic_dict_attack_advance(instance, state);
+            } else {
                 nfc_magic_scene_mf_classic_dict_attack_proceed_to_write(instance);
-                consumed = true;
             }
+            consumed = true;
         }
     } else if(event.type == SceneManagerEventTypeBack) {
         scene_manager_previous_scene(instance->scene_manager);
@@ -305,11 +377,11 @@ void nfc_magic_scene_mf_classic_dict_attack_on_exit(void* context) {
     scene_manager_set_scene_state(
         instance->scene_manager,
         NfcMagicSceneMfClassicDictAttack,
-        DictAttackStateUserDictInProgress);
+        DictAttackStateKeyCacheInProgress);
 
-    keys_dict_free(instance->nfc_dict_context.dict);
-    instance->nfc_dict_context.dict = NULL; // so a back-out free in write-check can't double-free
+    nfc_magic_app_free_dict_attack_keys(instance);
 
+    instance->nfc_dict_context.cache_key_index = 0;
     instance->nfc_dict_context.current_sector = 0;
     instance->nfc_dict_context.sectors_total = 0;
     instance->nfc_dict_context.sectors_read = 0;

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_mf_classic_write_check.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_mf_classic_write_check.c
@@ -75,11 +75,9 @@ void nfc_magic_scene_mf_classic_write_check_on_exit(void* context) {
     instance->write_problems_context.problems.all_problems = 0;
 
     // Backing out to the menu pops the dict-attack scene without running its on_exit, leaking its
-    // KeysDict; free it here if still owned (dict-attack on_exit NULLs it on the forward path).
-    if(instance->nfc_dict_context.dict) {
-        keys_dict_free(instance->nfc_dict_context.dict);
-        instance->nfc_dict_context.dict = NULL;
-    }
+    // key source; free it here if still owned (dict-attack on_exit clears the pointers on the
+    // forward path).
+    nfc_magic_app_free_dict_attack_keys(instance);
 
     write_problems_reset(instance->write_problems);
 }


### PR DESCRIPTION
# What's new

Adds a **key cache phase** to the NFC Magic MIFARE Classic dictionary attack, ahead of the two shared dictionaries:

```
Key cache  ->  User dict  ->  System dict  ->  Write / Wipe
```

A magic clone carries the original card's UID, so when the original was saved in the NFC app the firmware already wrote its keys to `/ext/nfc/.cache/<UID>.keys` - under exactly the filename the clone answers to. NFC Magic never looked there.

That dead-ended static-encrypted-nonce cards (FM11RF08S), whose keys only ever reach the per-UID (CUID) dictionary that MFKey32's `static_encrypted` branch writes: read the card in the NFC app, clone it to a Gen2 magic tag, then try to wipe the clone - neither shared dictionary has the keys, so it stopped at `WipeFail(NoKeys)`.

Both **Write** and **Wipe** route through the same dictionary-attack scene, so one phase covers both.

**Cached keys are served as a dictionary, through `MfClassicPollerEventTypeRequestKey` - they are never written into `target_dev` as already-found.** The poller trusts pre-found keys and skips re-authentication, so injected keys would produce a clean-looking wipe that authenticated nothing; that is the trap the `nfc_device_clear()` at the top of the scene exists to prevent. Served this way, a cached key is only ever marked found after a successful auth with it, so a stale or wrong entry costs a few failed auths and nothing else. For the sector the poller is on the phase offers key A, then key B, then nothing - roughly three authentications per sector instead of a dictionary walk, and the key-reuse pass still runs and still helps.

**On a cache miss the phase is skipped outright** - no header, no poller pass - so a blank card, a card that was never saved in the NFC app, or one reached through a backdoor wakeup (no standard activation, hence no UID) behaves exactly as it did before.

Two smaller things the phase brought with it:

- **The chain now stops once the card is provably fully read**, which in practice only the cache phase can manage on its own. Each further phase restarts the poller and reloads its dictionary, and the system one is a ~67 KB read on the GUI thread, so a cache hit that already finished the card used to pay for roughly a second of work that could find nothing. The dictionary phases still chain to each other exactly as before.
- **A cache file that exists but is unusable is logged** (`FURI_LOG_W`). A card with no entry is the ordinary case and stays silent, but a truncated or wrong-version entry is indistinguishable from it on screen, and the fix - re-save the card in the NFC app - is unguessable without a line in the log.

Four commits:

- **carry the scanned card's UID through to the app** - the scanner already activated ISO14443-3A and read the whole UID, then kept only its length and the first two bytes for the unpersonalized UL-5 heuristic. Keep all of it. The Gen1-only 4/7 length normalisation moves to the Gen1 branch that needs it, and the UL-5 `AA 55` check now states the length precondition it previously only met by luck.
- **read the NFC app's per-UID key cache** - `helpers/mfc_key_cache.{c,h}`, a local read-only twin of the firmware's `.keys` reader, wrapping the same `MfClassicDeviceKeys` the firmware's own holder wraps. That reader is internal to the NFC app and not exported through the API, so this needs no firmware change and no API export. Loading either yields an entry with at least one key in it or yields nothing at all, so a truncated entry can never be mistaken for a partial one.
- **try the key cache before the dictionaries** - the phase itself. The two chained phases become three, so the poller teardown/restart they duplicated moves into one helper and the chain is stated once, as the enum's own order, rather than once per event arm. Freeing the phase's key source moves into `nfc_magic_app_free_dict_attack_keys()` so the scene and both write-check back-outs release whichever of the two is held.
- **bump to 2.1 and log the key cache phase**

Related, on the firmware side: DarkFlippers/unleashed-firmware#1118 (merged) adds a "Save Keys to Dictionary" action so recovered keys can reach the shared user dictionary. The two are complementary - this one covers cards whose original was saved in the NFC app (no dictionary growth at all), that one covers cards where it wasn't.

Closes #257

# Verification

**Builds clean** with standalone `ufbt` against the Unleashed `dev` SDK - the same index and channel `.github/workflows/pr-build.yml` uses (Target 7, API 88.4). `ufbt lint` passes. The build is `-Werror`, and each of the four commits was built on its own, so the history is bisectable.

**Not hardware-tested.** It needs an FM11RF08S plus a Gen2 magic card, which I don't have here, so the sequence below is what it should do, not what was observed.

1. NFC app: read the FM11RF08S (the CUID dictionary recovers the keys) and **save** it - that writes `/ext/nfc/.cache/<UID>.keys`.
2. NFC Magic: clone it to the Gen2 magic card.
3. NFC Magic: **Wipe** the clone. Before this change it fails with "No keys found"; after it should show **MF Classic Key Cache** as the first phase, find the keys there, and wipe cleanly. If the cache covers the whole card, the two dictionary phases should not run at all.
4. Regression: **Wipe** a fresh blank Gen2 card, which has no cache entry. The first header should be **MF Classic User Dictionary** with no key-cache phase shown at all, and the user and system phases should behave exactly as before.
5. Regression: **Write** a dump to a Gen2 card, and to a plain (non-magic) MIFARE Classic card - both route through the same scene.
6. Regression: press **Skip** during each phase, and **Back** out of the dictionary attack and out of the write-check screen, to exercise the paths that free the phase's key source.
7. Optional, for the logging: corrupt or truncate a `/ext/nfc/.cache/<UID>.keys` entry and confirm the phase is skipped and a warning naming the file appears in the log (Settings -> Log Level = Warn or lower, read over CLI with `log`).

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code is released under GPLv3 license and can be edited, or published according to the opensource license
- [x] I have bumped `fap_version` in the app's `application.fam`
- [x] I have added an entry to the app's `CHANGELOG.md` describing the change

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

All of the code here was written by Claude Code from a design I specified - the phase ordering, the "serve as a dictionary, never inject into `target_dev`" constraint, the per-sector serving strategy, and the decision to write a local reader rather than export an API symbol - then reviewed by me. What it does:

- `magic/nfc_magic_scanner.{c,h}`: `NfcMagicScannerIdentity` keeps the full ISO14443-3A UID from the activation instead of just its length and first two bytes. It is carried on the scanner instance and out through `NfcMagicScannerEventData`, and `scenes/nfc_magic_scene_check.c` stores it on `NfcMagicApp` as `card_uid`/`card_uid_len`, which is 0 for a card with no standard activation.
- `helpers/mfc_key_cache.{c,h}`: `mfc_key_cache_load()` opens `/ext/nfc/.cache/<UID>.keys` as a `FlipperFormat` buffered file, checks the `Flipper NFC keys` header and version 1, reads the `Key A map` / `Key B map` bitmasks and then, for each sector the maps flag, the `Key A sector N` / `Key B sector N` entries - the same order the firmware's writer emits, because `flipper_format` only ever scans forward. It returns an opaque `MfcKeyCache*` only when the parse completed and the entry holds at least one key; every other outcome frees what it allocated and returns NULL. One accessor on top resolves `(sector, key type)` to a key.
- `scenes/nfc_magic_scene_mf_classic_dict_attack.c`: a third `DictAttackState` ahead of the existing two, declared so that the enum's order is the chain order. `prepare_view` loads the cache for the scanned UID and, on a miss, falls straight through to the user-dictionary phase without touching the header. `RequestKey` and the dictionary rewind go through small helpers that pick the active key source; the cache's cursor is a two-step A-then-B index keyed to `current_sector`, reset when the poller moves sector. The phase-advance code that `DictAttackComplete` and `DictAttackSkip` duplicated becomes one `advance()` helper - which also ends the chain when `mf_classic_is_card_read()` says there is nothing left to find - with the Skip semantics unchanged (skipping once the card is gone proceeds to write). A `furi_assert` pins the one invariant with two representations: the phase in the scene state and the key source the worker thread selects on must agree, and `prepare_view` is the only place both are written.
- `nfc_magic_app.{c,h}`: `nfc_magic_app_free_dict_attack_keys()` frees whichever key source the dict attack holds and clears the pointer, replacing the two open-coded `KeysDict` frees in the write-check scenes - and replacing an unconditional `keys_dict_free()` in the scene's `on_exit` that the cache phase's NULL dictionary would otherwise have tripped over.

# Checklist (For Reviewer) (Don't fill this out!):

- [ ] PR has proper description of new app/feature/bugfix
- [ ] Description contains actions to verify app/feature/bugfix on the hardware
- [ ] No obvious issues with the code was found
- [ ] I've built this app/code, uploaded it to the device and verified app/feature/bugfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
