### PR TITLE
NFC Magic: probe Gen2 CUID with the key cache's sector 0 keys

### DIFF
--- a/base_pack/nfc_magic/CHANGELOG.md
+++ b/base_pack/nfc_magic/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.2
+
+### Changed
+
+- **Gen2 detection now tries the per-UID key cache for sector 0.** Confirming a CUID means
+  authenticating to sector 0 before block 0 can be probed, and the probe only ever knew the
+  default FF..FF key, so a clone with a personalised sector 0 and no recognised ATS came back as
+  **Magic Not Confirmed**. The sector-0 key A and key B the NFC app recorded for that UID in
+  `/ext/nfc/.cache/<UID>.keys` are now offered first, ahead of FF..FF, so such a card can be
+  confirmed as Gen 2 / CUID and still gets its static-nonce classification. The cache is read once
+  per card per scan, a card with no entry behaves exactly as before, and a cached key that doesn't
+  fit costs one more RF session and nothing else: the probe itself is unchanged, still only the
+  first phase of the write, so block 0 is never modified.
+
 ## 2.1
 
 ### Added

--- a/base_pack/nfc_magic/application.fam
+++ b/base_pack/nfc_magic/application.fam
@@ -10,7 +10,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="Application for writing to NFC tags with modifiable sector 0",
-    fap_version="2.1",
+    fap_version="2.2",
     fap_icon="assets/Nfc_10px.png",
     fap_category="NFC",
     fap_icon_assets="assets",

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.c
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.c
@@ -6,12 +6,16 @@
 #include "protocols/gen2/gen2_poller.h"
 #include "protocols/gen4/gen4_poller.h"
 #include "protocols/uscuid_ul/uscuid_ul_poller.h"
+#include "../helpers/mfc_key_cache.h"
 #include <nfc/nfc_poller.h>
 #include <nfc/protocols/iso14443_3a/iso14443_3a.h>
 
 #include <furi/furi.h>
 
 #define TAG "NfcMagicScanner"
+
+// One key A plus one key B for sector 0 is everything the key cache can offer the CUID probe.
+#define NFC_MAGIC_SCANNER_MFC_PROBE_KEYS_MAX (2)
 
 typedef enum {
     NfcMagicScannerSessionStateIdle,
@@ -21,6 +25,7 @@ typedef enum {
 
 struct NfcMagicScanner {
     Nfc* nfc;
+    Storage* storage;
     NfcMagicScannerSessionState session_state;
 
     Gen4Password gen4_password;
@@ -30,6 +35,14 @@ struct NfcMagicScanner {
     uint8_t uid[ISO14443_3A_MAX_UID_SIZE];
     uint8_t uid_len;
     UscuidUlData uscuid_ul_data;
+
+    // Sector-0 keys the key cache holds for the card named by mfc_probe_uid, handed to the Gen2
+    // CUID write probe. Kept across detect passes so the cache is read once per card, not once
+    // per pass; mfc_probe_uid_len is 0 until the first lookup of a session.
+    Gen2ProbeKey mfc_probe_keys[NFC_MAGIC_SCANNER_MFC_PROBE_KEYS_MAX];
+    size_t mfc_probe_key_count;
+    uint8_t mfc_probe_uid[ISO14443_3A_MAX_UID_SIZE];
+    uint8_t mfc_probe_uid_len;
 
     NfcMagicScannerCallback callback;
     void* context;
@@ -50,14 +63,24 @@ static void nfc_magic_scanner_reset(NfcMagicScanner* instance) {
     memset(instance->uid, 0, sizeof(instance->uid));
     instance->uid_len = 0;
     memset(&instance->uscuid_ul_data, 0, sizeof(UscuidUlData));
+    instance->mfc_probe_key_count = 0;
+    memset(instance->mfc_probe_uid, 0, sizeof(instance->mfc_probe_uid));
+    instance->mfc_probe_uid_len = 0;
 }
 
-NfcMagicScanner* nfc_magic_scanner_alloc(Nfc* nfc) {
+NfcMagicScanner* nfc_magic_scanner_alloc(Nfc* nfc, Storage* storage) {
     furi_assert(nfc);
+    furi_assert(storage);
 
     NfcMagicScanner* instance = malloc(sizeof(NfcMagicScanner));
     instance->nfc = nfc;
+    instance->storage = storage;
     instance->gen4_data = gen4_alloc();
+    // Nothing else initialises the scan state before the first session: start doesn't reset, and
+    // reset otherwise runs only once the worker exits. The probe memo below in particular has to
+    // begin zeroed -- a chance match against malloc'd bytes would skip the lookup and hand
+    // gen2_poller_detect_type a garbage key count to iterate.
+    nfc_magic_scanner_reset(instance);
 
     return instance;
 }
@@ -123,6 +146,50 @@ static bool nfc_magic_scanner_detect_mf_classic(Nfc* nfc) {
     return detected;
 }
 
+// Key B before key A, matching the probe's own FF..FF pair: where a sector has been personalised
+// at all, write access is the permission more often kept for key B. Guessing wrong costs one RF
+// session, so this is a preference and not a requirement.
+static const MfClassicKeyType nfc_magic_scanner_mfc_probe_key_types[] = {
+    MfClassicKeyTypeB,
+    MfClassicKeyTypeA,
+};
+_Static_assert(
+    COUNT_OF(nfc_magic_scanner_mfc_probe_key_types) <= NFC_MAGIC_SCANNER_MFC_PROBE_KEYS_MAX,
+    "Scanner probe key array too small for the key types tried");
+
+// Collects the sector-0 keys the NFC app recorded for this UID (read_identity above says why a
+// clone's UID names them). They are what gets a personalised clone as far as the CUID write probe
+// at all, since the probe's default FF..FF opens only a blank sector 0. The lookup is memoised per
+// UID, hit or miss, so repeating a detect pass on the same card touches no storage.
+static void nfc_magic_scanner_load_mfc_probe_keys(
+    NfcMagicScanner* instance,
+    const uint8_t* uid,
+    uint8_t uid_len) {
+    if(instance->mfc_probe_uid_len == uid_len &&
+       memcmp(instance->mfc_probe_uid, uid, uid_len) == 0) {
+        return;
+    }
+
+    instance->mfc_probe_key_count = 0;
+    memcpy(instance->mfc_probe_uid, uid, uid_len);
+    instance->mfc_probe_uid_len = uid_len;
+
+    MfcKeyCache* key_cache = mfc_key_cache_load(instance->storage, uid, uid_len);
+    if(key_cache == NULL) return;
+
+    for(size_t i = 0; i < COUNT_OF(nfc_magic_scanner_mfc_probe_key_types); i++) {
+        const MfClassicKeyType key_type = nfc_magic_scanner_mfc_probe_key_types[i];
+        Gen2ProbeKey* probe_key = &instance->mfc_probe_keys[instance->mfc_probe_key_count];
+        if(mfc_key_cache_get_key(key_cache, 0, key_type, &probe_key->key)) {
+            probe_key->key_type = key_type;
+            instance->mfc_probe_key_count++;
+        }
+    }
+    FURI_LOG_D(TAG, "Sector 0 keys from cache: %u", (unsigned)instance->mfc_probe_key_count);
+
+    mfc_key_cache_free(key_cache);
+}
+
 static bool nfc_magic_scanner_detect_not_magic(Nfc* nfc) {
     for(size_t i = 0; i < COUNT_OF(nfc_magic_scanner_not_magic_protocols); i++) {
         NfcPoller* poller = nfc_poller_alloc(nfc, nfc_magic_scanner_not_magic_protocols[i]);
@@ -183,7 +250,12 @@ static bool nfc_magic_scanner_detect_pass(NfcMagicScanner* instance, NfcMagicPro
             *protocol = NfcMagicProtocolGen1;
             return true;
         }
-        if(gen2_poller_detect_type(instance->nfc, &instance->gen2_type) == Gen2PollerErrorNone) {
+        nfc_magic_scanner_load_mfc_probe_keys(instance, id.uid, id.uid_len);
+        if(gen2_poller_detect_type(
+               instance->nfc,
+               instance->mfc_probe_keys,
+               instance->mfc_probe_key_count,
+               &instance->gen2_type) == Gen2PollerErrorNone) {
             *protocol = NfcMagicProtocolGen2;
             return true;
         }

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.h
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.h
@@ -6,6 +6,7 @@
 #include "protocols/nfc_magic_protocols.h"
 #include "protocols/gen2/gen2_poller.h"
 #include "protocols/uscuid_ul/uscuid_ul_poller.h"
+#include <storage/storage.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,7 +36,10 @@ typedef void (*NfcMagicScannerCallback)(NfcMagicScannerEvent event, void* contex
 
 typedef struct NfcMagicScanner NfcMagicScanner;
 
-NfcMagicScanner* nfc_magic_scanner_alloc(Nfc* nfc);
+// storage is used to look up the NFC app's per-UID MIFARE Classic key cache, whose sector-0 keys
+// widen the Gen2 CUID write probe beyond the default FF..FF. It is borrowed, never freed here, and
+// must outlive the scanner.
+NfcMagicScanner* nfc_magic_scanner_alloc(Nfc* nfc, Storage* storage);
 
 void nfc_magic_scanner_free(NfcMagicScanner* instance);
 

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
@@ -237,14 +237,10 @@ Gen2PollerError gen2_poller_detect(Nfc* nfc) {
 
 #define GEN2_STATIC_NONCE_SAMPLES (3)
 
-// Default sector-0 keys tried for the CUID write probe. Blank/fresh magic cards
-// (and blank normal cards) use FF..FF; matching Proxmark3 we try B then A.
-typedef struct {
-    MfClassicKeyType key_type;
-    MfClassicKey key;
-} Gen2ProbeKey;
-
-static const Gen2ProbeKey gen2_cuid_probe_keys[] = {
+// Fallback sector-0 keys for the CUID write probe, tried after whatever card-specific keys the
+// caller supplied. Blank/fresh magic cards (and blank normal cards) use FF..FF; matching
+// Proxmark3 we try B then A.
+static const Gen2ProbeKey gen2_cuid_default_probe_keys[] = {
     {MfClassicKeyTypeB, {.data = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}}},
     {MfClassicKeyTypeA, {.data = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}}},
 };
@@ -328,18 +324,47 @@ static void
     ctx->poller = NULL;
 }
 
-static bool gen2_poller_probe_cuid(Nfc* nfc) {
-    for(size_t i = 0; i < COUNT_OF(gen2_cuid_probe_keys); i++) {
-        Gen2DetectContext ctx = {
-            .key = gen2_cuid_probe_keys[i].key,
-            .key_type = gen2_cuid_probe_keys[i].key_type,
-            .cuid_writable = false,
-        };
-        gen2_poller_run_detect_session(nfc, gen2_poller_cuid_probe_callback, &ctx);
-        if(ctx.cuid_writable) {
+static bool gen2_poller_probe_cuid_with_key(Nfc* nfc, const Gen2ProbeKey* probe_key) {
+    Gen2DetectContext ctx = {
+        .key = probe_key->key,
+        .key_type = probe_key->key_type,
+        .cuid_writable = false,
+    };
+    gen2_poller_run_detect_session(nfc, gen2_poller_cuid_probe_callback, &ctx);
+
+    return ctx.cuid_writable;
+}
+
+static bool gen2_probe_key_already_tried(
+    const Gen2ProbeKey* tried_keys,
+    size_t tried_key_count,
+    const Gen2ProbeKey* probe_key) {
+    for(size_t i = 0; i < tried_key_count; i++) {
+        if(tried_keys[i].key_type == probe_key->key_type &&
+           memcmp(tried_keys[i].key.data, probe_key->key.data, sizeof(MfClassicKey)) == 0) {
             return true;
         }
     }
+
+    return false;
+}
+
+// Card-specific keys go first: they are this card's own sector-0 keys, so they are likelier to
+// authenticate than FF..FF. The auth gates gen2_poller_probe_block0_writable, so on a card with a
+// personalised sector 0 they are the only keys that reach the write probe at all. Every key that
+// doesn't confirm CUID costs one more RF session, which is also why a default that the caller
+// already handed us is not sent twice: plenty of saved cards keep a default sector 0.
+static bool
+    gen2_poller_probe_cuid(Nfc* nfc, const Gen2ProbeKey* extra_keys, size_t extra_key_count) {
+    for(size_t i = 0; i < extra_key_count; i++) {
+        if(gen2_poller_probe_cuid_with_key(nfc, &extra_keys[i])) return true;
+    }
+    for(size_t i = 0; i < COUNT_OF(gen2_cuid_default_probe_keys); i++) {
+        const Gen2ProbeKey* default_key = &gen2_cuid_default_probe_keys[i];
+        if(gen2_probe_key_already_tried(extra_keys, extra_key_count, default_key)) continue;
+        if(gen2_poller_probe_cuid_with_key(nfc, default_key)) return true;
+    }
+
     return false;
 }
 
@@ -380,9 +405,14 @@ static bool gen2_poller_probe_static_nonce(Nfc* nfc) {
     return false;
 }
 
-Gen2PollerError gen2_poller_detect_type(Nfc* nfc, Gen2Type* type) {
+Gen2PollerError gen2_poller_detect_type(
+    Nfc* nfc,
+    const Gen2ProbeKey* extra_keys,
+    size_t extra_key_count,
+    Gen2Type* type) {
     furi_assert(nfc);
     furi_assert(type);
+    furi_assert(extra_keys != NULL || extra_key_count == 0);
 
     *type = Gen2TypeUnknown;
 
@@ -394,7 +424,7 @@ Gen2PollerError gen2_poller_detect_type(Nfc* nfc, Gen2Type* type) {
 
     // 2. Behavioural CUID confirmation, then static-nonce classification. Each probe
     // runs in its own poller session (allocated per session in run_detect_session).
-    if(gen2_poller_probe_cuid(nfc)) {
+    if(gen2_poller_probe_cuid(nfc, extra_keys, extra_key_count)) {
         *type = gen2_poller_probe_static_nonce(nfc) ? Gen2TypeCuidStaticNonce : Gen2TypeCuid;
     }
 

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
@@ -109,9 +109,23 @@ typedef struct Gen2Poller Gen2Poller;
 
 Gen2PollerError gen2_poller_detect(Nfc* nfc);
 
+// One key the CUID write probe can try to open sector 0 with.
+typedef struct {
+    MfClassicKeyType key_type;
+    MfClassicKey key;
+} Gen2ProbeKey;
+
 // Detects whether the card is Gen2 and classifies its sub-type (ATS / CUID /
 // CUID with static nonce). Returns Gen2PollerErrorNone when any Gen2 type is found.
-Gen2PollerError gen2_poller_detect_type(Nfc* nfc, Gen2Type* type);
+// extra_keys are sector-0 keys already known to belong to this particular card; the CUID write
+// probe tries them in the order given, ahead of its FF..FF defaults. The probe is gated behind a
+// successful auth, so without them it cannot reach a card whose sector 0 no longer carries the
+// default key. Pass NULL/0 when none are known.
+Gen2PollerError gen2_poller_detect_type(
+    Nfc* nfc,
+    const Gen2ProbeKey* extra_keys,
+    size_t extra_key_count,
+    Gen2Type* type);
 
 // Gen2 sub-type detail shown under the "Gen 2" type line (e.g. "CUID. Static nonce"),
 // or NULL if none.

--- a/base_pack/nfc_magic/nfc_magic_app.c
+++ b/base_pack/nfc_magic/nfc_magic_app.c
@@ -126,7 +126,7 @@ NfcMagicApp* nfc_magic_app_alloc() {
         write_problems_get_view(instance->write_problems));
 
     instance->nfc = nfc_alloc();
-    instance->scanner = nfc_magic_scanner_alloc(instance->nfc);
+    instance->scanner = nfc_magic_scanner_alloc(instance->nfc, instance->storage);
 
     return instance;
 }
@@ -195,14 +195,14 @@ void nfc_magic_app_free(NfcMagicApp* instance) {
     furi_record_close(RECORD_DIALOGS);
     instance->dialogs = NULL;
 
-    // Storage
-    furi_record_close(RECORD_STORAGE);
-    instance->storage = NULL;
-
     gen4_free(instance->gen4_data);
 
     nfc_magic_scanner_free(instance->scanner);
     nfc_free(instance->nfc);
+
+    // Storage, closed after the scanner: the scanner borrows this handle for its key cache lookups.
+    furi_record_close(RECORD_STORAGE);
+    instance->storage = NULL;
 
     free(instance);
 }


### PR DESCRIPTION
# What's new

Gen2 detection now authenticates sector 0 with the keys the NFC app already recorded for the card, instead of only `FF FF FF FF FF FF`.

Confirming a CUID is a behavioural check: authenticate to sector 0, send the first phase of a write to block 0, and take an ACK as proof that block 0 is directly writable. The auth is the gate, and it only ever tried the default key. A magic clone carries the sector 0 trailer of the card it was made from along with its UID, so the default key is precisely what a good clone does not have - both auths failed, the write probe was never reached, and the card came out as a plain MIFARE Classic:

```
Magic Not Confirmed
Not a magic tag, or
sector 0 key is non-standard.
Try writing to confirm.
```

Those keys are usually already on the SD card. Saving a card in the NFC app writes everything it recovered to `/ext/nfc/.cache/<UID>.keys`, under the same UID the clone answers to - the file #258 taught the dictionary attack to read. Detection now reads it too and hands sector 0's key A and key B to the CUID probe.

Card-specific keys go first, ahead of the FF..FF defaults: they are the card's own keys, so they are likelier to authenticate, and a personalised card reaches the probe without paying for two attempts that cannot work. A default the cache already supplied is not sent twice - plenty of saved cards keep a default sector 0, and every probe key is a full RF session.

**The probe itself is untouched.** It still sends only the first phase of the write and drops the field before any data phase, so block 0 is never modified whether the card ACKs or NAKs, and a genuine MIFARE Classic still NAKs its read-only manufacturer block. A valid key gets a card *to* the probe; it does not change the verdict, so this is not a false-positive source.

What it does change is which cards get that far: a personalised card that the user has saved in the NFC app now receives an authenticated write-phase-1 to block 0 during a plain **Check**, where before it failed auth and stopped there. Safe by the probe's construction, but it is a widening, and worth signing off on knowingly rather than discovering later.

Two consequences beyond the type line:

- The card is routed to the **Gen 2** menu instead of the MF Classic menu, so the Gen2-specific actions are offered for it.
- The **static-nonce classification runs**, since it is gated behind CUID confirmation. A clone of an FM11RF08S is now flagged as one.

**On a cache miss nothing changes.** No entry, no sector 0 keys in the entry, or a card with no standard activation and therefore no UID: the probe runs exactly the two FF..FF attempts it ran before. The lookup is memoised per UID and sits on the Gen2 branch only, so Gen1, Gen4, USCUID-UL and ATS-identified Gen2 cards touch no storage at all.

Closes #260

# Verification

**Builds clean** with standalone `ufbt` against the Unleashed `dev` SDK - the same index and channel `.github/workflows/pr-build.yml` uses (Target 7, API 88.4). `ufbt lint` passes, and the build is `-Werror`.

**Flashed to a Flipper and running.** The card-level sequence below is what it should do:

1. Take a Gen2/CUID card that is not on the ATS fingerprint list, blank. NFC Magic -> **Check** reports **Gen 2**, detail **CUID**. This is the baseline.
2. Clone a real personalised MIFARE Classic onto it, so sector 0 no longer carries `FF..FF`. **Check** now reports **Magic Not Confirmed** - the bug.
3. In the NFC app, read and **save** the original card. That writes `/ext/nfc/.cache/<UID>.keys`.
4. **Check** the clone again. It should report **Gen 2 / CUID**, or **CUID. Static nonce** if the original was an FM11RF08S.

`FURI_LOG_D` reports what the lookup found (`Sector 0 keys from cache: N`), so `log debug` over CLI distinguishes "no entry" from "entry with no sector 0 keys" from "keys offered and rejected". The lookup runs once per scan, so re-enter Check after editing the file.

Regressions worth walking:

5. A blank Gen2 card with no cache entry - still confirms, and no slower than before, since the cached-`FF..FF` case is deduplicated rather than probed twice.
6. A **genuine** MIFARE Classic that *has* been saved in the NFC app - must still report Not Confirmed, and block 0 must be byte-identical afterwards. This is the one that exercises the widening above; read the card back in the NFC app to confirm.
7. Gen1a, Gen4, USCUID-UL and a plain Ultralight - unchanged, none of those paths reads storage.
8. Write and Wipe on a Gen2 clone - unchanged, they already ran the full dictionary attack before writing.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code is released under GPLv3 license and can be edited, or published according to the opensource license
- [x] I have bumped `fap_version` in the app's `application.fam`
- [x] I have added an entry to the app's `CHANGELOG.md` describing the change

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The code was written by Claude Code from a design I specified - use the per-UID key cache #258 introduced to widen the Gen2 CUID probe's sector 0 authentication - then reviewed by me. What it does:

- `magic/protocols/gen2/gen2_poller.{c,h}`: `Gen2ProbeKey` (a key plus the type it authenticates as) moves to the public header, and `gen2_poller_detect_type()` takes `extra_keys`/`extra_key_count`. The probe walks those in the order given, then its own `FF..FF` pair, skipping any default the caller already supplied. The per-key session body is factored into `gen2_poller_probe_cuid_with_key()`; `gen2_poller_probe_block0_writable()` and the ATS fingerprint step are unchanged.
- `magic/nfc_magic_scanner.{c,h}`: the scanner takes a borrowed `Storage*` and, on the Classic branch only and only after the Gen1 probe has failed, loads the cache entry for the UID it already read during activation, keeping sector 0's key B then key A. The result is memoised against that UID, hit or miss, so a detect pass that repeats reads the file once rather than once per pass; a `_Static_assert` pins the array to the two keys the cache can offer for one sector. `nfc_magic_scanner_alloc()` now resets the instance it just `malloc`'d, which the memo requires and which also stops the first scan of a session reading garbage for `gen2_type`, `uid` and `uscuid_ul_data`.
- `nfc_magic_app.c`: passes the app's `Storage*` to the scanner, and closes the storage record after freeing the scanner that borrows its handle rather than before.

# Checklist (For Reviewer) (Don't fill this out!):

- [ ] PR has proper description of new app/feature/bugfix
- [ ] Description contains actions to verify app/feature/bugfix on the hardware
- [ ] No obvious issues with the code was found
- [ ] I've built this app/code, uploaded it to the device and verified app/feature/bugfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
