### PR TITLE
VGM Tool: make the SWDIO direction switch atomic

### DIFF
--- a/base_pack/video_game_module_tool/CHANGELOG.md
+++ b/base_pack/video_game_module_tool/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## 1.4
+
+- Fix the SWDIO direction switch corrupting the Flipper's internal I2C bus, which could leave the
+  desktop showing the error battery until the Flipper was rebooted: the raw `LL_GPIO_SetPinMode()`
+  in `swd_turnaround()` is a read-modify-write of `GPIOA->MODER`, where PA9/PA10 are the fuel
+  gauge, charger and LED driver bus, and it ran with interrupts enabled - a turnaround preempted
+  between the load and the store wrote back a stale value and pulled those pins out from under an
+  I2C transaction that was in flight
+
+## 1.3
+
+- Remove the call to the deprecated `view_dispatcher_enable_queue()` SDK API
+
+## 1.2
+
+- Fix a crash caused by log output from inside a critical section
+- Fix a crash when the app was built with `DEBUG=1`
+
+## 1.1
+
+- Description update
+
+## 1.0
+
+- Initial release: standalone installer for Video Game Module firmware, either the official build
+  bundled with the app or a custom `.uf2` file picked from the microSD card

--- a/base_pack/video_game_module_tool/application.fam
+++ b/base_pack/video_game_module_tool/application.fam
@@ -9,7 +9,7 @@ App(
     ],
     stack_size=2048,
     fap_description="This app is a standalone firmware updater/installer for the Video Game Module",
-    fap_version="1.2",
+    fap_version="1.4",
     fap_icon="vgm_tool.png",
     fap_category="GPIO",
     fap_icon_assets="icons",

--- a/base_pack/video_game_module_tool/flasher/swd.c
+++ b/base_pack/video_game_module_tool/flasher/swd.c
@@ -86,8 +86,11 @@ static void __attribute__((optimize("-O3"))) swd_turnaround(SwdioDirection mode)
     }
 
     if(mode == SwdioDirectionIn) {
-        // Using LL functions for performance reasons
+        // Using LL functions for performance reasons, but MODER is shared with the internal
+        // I2C pins, so the read-modify-write has to be atomic like furi_hal_gpio_init_ex() is
+        FURI_CRITICAL_ENTER();
         LL_GPIO_SetPinMode(gpio_swdio.port, gpio_swdio.pin, LL_GPIO_MODE_INPUT);
+        FURI_CRITICAL_EXIT();
     } else {
         furi_hal_gpio_write(&gpio_swclk, false);
     }
@@ -98,8 +101,11 @@ static void __attribute__((optimize("-O3"))) swd_turnaround(SwdioDirection mode)
 
     if(mode == SwdioDirectionOut) {
         furi_hal_gpio_write(&gpio_swclk, false);
-        // Using LL functions for performance reasons
+        // Using LL functions for performance reasons, but MODER is shared with the internal
+        // I2C pins, so the read-modify-write has to be atomic like furi_hal_gpio_init_ex() is
+        FURI_CRITICAL_ENTER();
         LL_GPIO_SetPinMode(gpio_swdio.port, gpio_swdio.pin, LL_GPIO_MODE_OUTPUT);
+        FURI_CRITICAL_EXIT();
     }
 }
 


### PR DESCRIPTION
Fixes the root cause of DarkFlippers/unleashed-firmware#961: after using this app, the Flipper's desktop shows the error battery — an empty outline with a dash — and keeps showing it until the device is rebooted.

### What happens

`swd_turnaround()` flips SWDIO between input and output with a raw `LL_GPIO_SetPinMode()`, which is a read-modify-write of `GPIOA->MODER` performed with interrupts enabled:

```c
if(mode == SwdioDirectionIn) {
    // Using LL functions for performance reasons
    LL_GPIO_SetPinMode(gpio_swdio.port, gpio_swdio.pin, LL_GPIO_MODE_INPUT);
```

`gpio_swdio` is **PA13**. `gpio_i2c_power_scl` and `gpio_i2c_power_sda` are **PA9/PA10** — the same register. That is the Flipper's internal I2C bus: the BQ27220 fuel gauge, the BQ25896 charger and the LP5562 LED driver. The power service reconfigures those two pins from Analog to alternate function and back on every reading it takes, roughly 19 times a second, four `MODER` writes each.

Preempt a turnaround between the load and the store, and the stale value it writes back puts PA9/PA10 into whatever mode they held before — pulling the pins out from under an I2C transaction that is in flight. The firmware is careful about exactly this: `furi_hal_gpio_init_ex()` does the whole configuration inside `FURI_CRITICAL_ENTER()`, commented *"Configure gpio with interrupts disabled"*. The raw LL call bypasses it.

It is a race, so it does not fire every time — which matches the report, and matches why this has gone unnoticed. The window is small, but `swd_turnaround()` runs on the order of a hundred thousand times over a flash, and it also runs during probing: `scene_probe_on_event()` calls `flasher_init()` on every 500 ms tick while no module is attached, so the exposure starts as soon as the app is opened, not only during an install.

### The fix

Do the read-modify-write with interrupts off, the way `furi_hal_gpio_init_ex()` always has. The `-O3` bit-bang loops and `furi_hal_gpio_write()`/`furi_hal_gpio_read()` are untouched — those use `BSRR` and `IDR`, which are atomic. Only the two `MODER` writes are guarded, so the cost is a couple of dozen cycles per direction change against an SWD bit period, and the comment's original intent (avoid `furi_hal_gpio_init_ex()`'s full reconfiguration path on a hot loop) is preserved.

### Verification

`ufbt` builds clean, `APPCHK` passes (Target 7, API 88.4), `ufbt format` is a no-op on the change.

**The race is reproduced and measured on hardware.** No Video Game Module needed: I instrumented the firmware to check `GPIOA->MODER` at both ends of every internal I2C transaction - PA9/PA10 must read as alternate function while a transaction is live and as analog between them - and wrote a small app that hammers PA13 with the same read-modify-write `swd_turnaround()` does, unguarded for one phase and inside `FURI_CRITICAL` for the next. On an f7 hw_ver 12:

| phase | turnarounds / 15 s | MODER clobbers mid-transaction | gauge read errors |
|---|---|---|---|
| unguarded | 19,600,000 | **15** (of ~290 I2C transactions) | bursts of `bq27220_read_word failed` |
| guarded | 5,900,000 | **0** | none |

So roughly 5% of the internal I2C traffic was corrupted while the unguarded loop ran, and the critical section eliminates it completely.

The end state is the one from the issue. `OperationStatus.INITCOMP` on the BQ27220 read `1` before the test and `0` after, and it was still `0` forty seconds later; a reboot brought it back to `1`. `furi_hal_power_gauge_is_ok()` reads exactly that bit, so the Flipper sat showing the error battery until it was rebooted - the whole of #961, on the bench.

Two honest caveats. The hammer is a tight loop, so the *rate* above is an upper bound; a real flash spends most of its time bit-banging between turnarounds and will corrupt far fewer transactions. And I still have not run this against an actual module - what is demonstrated is the mechanism and the resulting stuck gauge, not a specific VGM flash.

### Changelog and version

The app had no `CHANGELOG.md`, so this adds one, filled in retrospectively the way the other apps in the pack have it — 1.0 to 1.2 from upstream's `.catalog/CHANGELOG.md`, 1.3 from this pack's own `a6b8020f`.

The version goes to **1.4**, not 1.3. This copy already carried upstream's 1.3 change — `a6b8020f` dropped the deprecated `view_dispatcher_enable_queue()` call back in August 2024 — but the manifest was never bumped for it, so it still read `1.2` while the code matched upstream `1.3`. Going straight to 1.4 keeps the numbering lined up with good-faps: upstream 1.3 is the same code, ours is that plus this fix.


