### PR TITLE
Update Fake Chip Detector to 0.11

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -260,7 +260,7 @@ The Flipper and its community wouldn't be as rich as it is without your contribu
 | GPS Track | ![GPIO Badge] | [by xumbax](https://github.com/xumbax/GPS-Track) |  | ![None Badge] |
 | BME280 Vario | ![GPIO Badge] | [by xumbax](https://github.com/xumbax/flipper-vario) |  | ![None Badge] |
 | ESP32 Hotspot Arcade | ![GPIO Badge] | [by tarikbc](https://github.com/tarikbc/hotspot-arcade) |  | [![Author Badge]](https://lab.flipper.net/apps/hotspot_arcade) |
-| Fake Chip Detector | ![GPIO Badge] | [by hleserg](https://github.com/hleserg/flipper-fake-chip-detector) | Reads an I2C sensor's factory ID register to tell whether it really is the chip it was sold as | ![None Badge] |
+| Fake Chip Detector | ![GPIO Badge] | [by hleserg](https://github.com/hleserg/flipper-fake-chip-detector) | Reads an I2C sensor's factory ID register to tell whether it really is the chip it was sold as | [![Author Badge]](https://lab.flipper.net/apps/fake_chip_detector) |
 | I2C BMS Reader | ![GPIO Badge] | [by gazirov](https://github.com/gazirov/battery_reader) | SBS battery reader/service tool for TI BQ30/BQ40 controllers (via I2C) | ![None Badge] |
 | IR Remote | ![IR Badge] | [by Hong5489](https://github.com/Hong5489/ir_remote) | improvements [by friebel](https://github.com/RogueMaster/flipperzero-firmware-wPlugins/pull/535) - Hold Option, RAW support [by d4ve10](https://github.com/d4ve10/ir_remote/tree/infrared_hold_option) | ![None Badge] |
 | IR Intervalometer | ![IR Badge] | [by Nitepone](https://github.com/Nitepone/flipper-intervalometer) |  | [![UFW Badge]](https://lab.flipper.net/apps/sony_intervalometer) |

--- a/non_catalog_apps/fake_chip_detector/CHANGELOG.md
+++ b/non_catalog_apps/fake_chip_detector/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.8 — beta
+
+- **The app no longer names a chip the bus never identified.** When more than one part fits
+  what was read — two chips with no ID register sharing an address, or two whose ID checks both
+  passed — the verdict is now **SEVERAL POSSIBLE** and every candidate is named, on the screen
+  and in the saved report. Previously the first row in the table won silently. This is not an
+  accusation: it says the tool cannot tell two real parts apart, which is a limit of two wires
+  and not a fault in the chip.
+- A silent device now keeps the failed reads that prove it went quiet. **NO ANSWER** used to
+  reach the detail screen with nothing on it.
+- **New chips: AK09911 and QMC5883P magnetometers.** 82 chips in the database now.
+- **New live test: AK09911.** It fires the part's built-in self-test coil, checks the answer
+  against the datasheet window after applying the fuse-ROM sensitivity correction, then asks
+  the field to move on two different axes. It has never been run on hardware.
+- The silent-bus screen now names **RST** alongside **XSHUT**, **RES** and **EN**, and the AK09911
+  carries a mode-pin row for it: that part answers nothing at all while its reset pad is low,
+  and the board it was reported on leaves that pad floating.
+
 ## 0.7 — beta
 
 - First public release, and deliberately not called 1.0. Everything here is built and reviewed,

--- a/non_catalog_apps/fake_chip_detector/CHANGELOG.md
+++ b/non_catalog_apps/fake_chip_detector/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.10 — beta
+
+- **A GY-271 board reading QMC5883P no longer looks like a contradiction.** The number
+  silkscreened on a module and the number burned into the die are different things, which is the
+  whole premise of this app, and the one screen that asks **Is this what you bought?** was the
+  one screen that never said so. The database already carried a note field for exactly this — the
+  MPU6500 has said **often sold as MPU9250** since the first release — but the note was only ever
+  drawn on the detail screen behind it. It is on the question screen now, above the verdict, for
+  every chip that has one.
+- **The QMC5883P carries that note: GY-271 board, not a 5883L.** GY-271 is the module name the
+  HMC5883L made famous and the number people still search for. The die inside one bought today is
+  usually a QST part, and a P is not register-compatible with either the HMC5883L or the
+  QMC5883L, so a driver written for the name on the silkscreen will not talk to it.
+- **The QMC5883P has a live test now.** It fires the part's internal self-test coil and checks
+  that all three channels deflect, then asks the field to move by 300 counts on two different
+  axes while the board is turned. The coil half is deliberately a floor rather than a
+  specification: QST's datasheet says to compare the deflection with a threshold value and then
+  publishes no threshold anywhere, so the test checks that a deflection happened at all, by a
+  margin three times the part's own documented noise. A GY-271 board passed it on 9 Sep 2026 —
+  1036 reads, the coil fired, the field followed the board — which makes the thresholds
+  reachable but not measured: the movement threshold is still arithmetic off the datasheet's
+  sensitivity figure, and the lesson from the AK09911 is that a threshold means nothing until
+  the still part's noise floor is measured under it. A second run on the same board exposed two
+  faults, both fixed here: the self-test was waiting on a data-ready flag the part stops
+  producing when the self-test ends, and the measurement was configured on top of whatever the
+  previous run had left rather than from a soft reset.
+- **The QMC5883P row has met a part.** It was added in 0.8 from its datasheet with nothing to
+  answer it. On 9 Sep 2026 a blue GY-271 board answered at 0x2C and read 0x80 at register 0x00,
+  which is that row and no other.
+
+## 0.9 — beta
+
+- **The AK09911 live test could not pass, and now it has.** It asked for the field to swing 100
+  counts on two axes. The earth puts about 50 counts into the whole vector, so no single axis
+  can swing that far however hard the board is waved — the threshold had been calibrated
+  against a bench capture with a magnet next to the sensor. Measured on a real part: two and a
+  half minutes of turning plateaued at 38/47/26 counts against a stationary noise floor of
+  4/5/7. The threshold is now 30, and the test passes in about ten seconds.
+- **The test screen said nothing about what to do.** It showed raw counts and a clock. The
+  instruction and the progress count were written to a third line that the screen has no room
+  to draw under a heading and progress boxes, so both were composed and silently dropped. The
+  first line is now the instruction, carrying its own feedback: **Turn it over - 1/2 axes**.
+- A saturated sensor used to freeze the display. The overflow branch skipped the screen update
+  and went round again, and the flag stays set for as long as the magnet is there, so the
+  advice to back off never appeared.
+- The passed screen lost its **not parked** warning to the same missing third line. That one
+  matters: it means the part was left in continuous mode.
+
+First release with an AK09911 on the bench. The identification, the reset guidance and the
+live test in 0.8 had all been written from datasheets alone.
+
 ## 0.8 — beta
 
 - **The app no longer names a chip the bus never identified.** When more than one part fits

--- a/non_catalog_apps/fake_chip_detector/LIVE_TESTS.md
+++ b/non_catalog_apps/fake_chip_detector/LIVE_TESTS.md
@@ -219,6 +219,11 @@ tick when it is reached. Pick something the part cannot fake by holding still:
   like 1 g on Z forever; it cannot hand the weight over to X when the board is tipped.
 - **AHT / SHT** — humidity rises 15 points above the lowest reading seen.
 - **MLX90614** — the object temperature runs 5 °C above the ambient the same part reports.
+- **AK09911** — the built-in self-test coil fires and the adjusted answer lands inside the
+  datasheet window (X and Y within ±30 counts, Z between −400 and −50), **and** the field
+  afterwards moves by 100 counts on two different axes. Same shape as BH1750: the self-test
+  alone says the magnetic sensor responds, and a part replaying a canned self-test answer
+  still cannot make that answer follow the room when the board is turned.
 
 Two of these are worth copying for the shape rather than the numbers. The BH1750 test insists
 on **both directions**, which is what stops a dead part passing by accident. The accelerometer

--- a/non_catalog_apps/fake_chip_detector/LIVE_TESTS.md
+++ b/non_catalog_apps/fake_chip_detector/LIVE_TESTS.md
@@ -33,7 +33,7 @@ which of the two they are looking at.
 Tests do not have to be built into the app. A test can be shipped as a single `.fal` file, and
 the app will find it, list it and run it — no rebuild, no reflash.
 
-1. Get the `.fal`. Build it yourself from [`test_plugin_template/`](https://github.com/hleserg/flipper-fake-chip-detector/tree/master/test_plugin_template), or
+1. Get the `.fal`. Build it yourself from [`test_plugin_template/`](../test_plugin_template), or
    take one somebody published.
 2. Open **Live tests** once. The app creates the folder it looks in, which saves you guessing at
    the spelling.
@@ -221,9 +221,27 @@ tick when it is reached. Pick something the part cannot fake by holding still:
 - **MLX90614** — the object temperature runs 5 °C above the ambient the same part reports.
 - **AK09911** — the built-in self-test coil fires and the adjusted answer lands inside the
   datasheet window (X and Y within ±30 counts, Z between −400 and −50), **and** the field
-  afterwards moves by 100 counts on two different axes. Same shape as BH1750: the self-test
+  afterwards moves by 30 counts on two different axes. Same shape as BH1750: the self-test
   alone says the magnetic sensor responds, and a part replaying a canned self-test answer
   still cannot make that answer follow the room when the board is turned.
+
+  Thirty is small because the earth is: the whole field vector is about 50 raw counts, so one
+  axis cannot swing more than a hundred however hard it is waved. The first version of this
+  test asked for a hundred on two axes and therefore could not pass at all — the threshold had
+  been calibrated against a bench capture with a magnet sitting next to the sensor. If you are
+  choosing a movement threshold for a magnetometer, measure the still part first: the noise
+  floor is the half that says whether the number means anything.
+
+- **QMC5883P** — the internal self-test coil deflects all three channels by more than the
+  part's own published noise, **and** the field afterwards moves by 300 counts on two different
+  axes at the ±8 G range. The coil half is deliberately a floor and not a specification: QST
+  says to "compare with threshold value" and then publishes no threshold anywhere in the
+  datasheet, so this checks that a deflection happened at all, by a margin three times the
+  documented standard deviation. Three hundred is arithmetic, not measurement — the earth is
+  0.25 to 0.65 G, which is 937 counts at the weakest place on earth and 1875 of swing when a
+  board is turned end over end — and it has never been compared against a still part. Do that
+  before trusting it. A GY-271 board passed this test on 9 Sep 2026, which makes the numbers
+  reachable but says nothing about how much room is under them.
 
 Two of these are worth copying for the shape rather than the numbers. The BH1750 test insists
 on **both directions**, which is what stops a dead part passing by accident. The accelerometer
@@ -293,7 +311,7 @@ A test does not have to be merged here to be useful. Built as a `.fal` and copie
 it appears in the browser and runs like any other — no rebuild of the app, no pull request, no
 waiting for anyone.
 
-Start from [`test_plugin_template/`](https://github.com/hleserg/flipper-fake-chip-detector/tree/master/test_plugin_template) in the upstream repository. It is a
+Start from [`test_plugin_template/`](../test_plugin_template) in the repository root. It is a
 complete working test, not a snippet: copy the folder, change the registers, the pass condition
 and the strings, then
 

--- a/non_catalog_apps/fake_chip_detector/README.md
+++ b/non_catalog_apps/fake_chip_detector/README.md
@@ -15,10 +15,11 @@ you bought?
   `/ext/apps_data/fake_chip_detector/`.
 - **Wiring diagnosis** with live per-line detection — missing pull-up, line shorted to ground,
   SDA shorted to SCL, or the module plugged into the wrong header pins entirely.
-- **14 live tests.** An ID register is one byte and a byte can be copied; a working sensor
+- **15 live tests.** An ID register is one byte and a byte can be copied; a working sensor
   cannot. Breathe on an AHT or SHT, cover a BH1750, tip an MPU6050 or ADXL345, wave at an
   APDS9960, point an MLX90614 at your palm, watch a DS3231 tick, blink an SSD1306, turn a BNO055
-  through a figure-8, wave an AK09911 through a field, hold a hand in front of a VL6180X.
+  through a figure-8, turn an AK09911 or a QMC5883P over and watch the earth's field follow it,
+  hold a hand in front of a VL6180X.
 - **1-Wire scanning** on pin 17 with a real temperature conversion, so a DS18S20 sold as a
   DS18B20 is caught.
 - Tests can also be **loaded from the SD card as .fal plugins** — see [LIVE_TESTS.md](LIVE_TESTS.md).

--- a/non_catalog_apps/fake_chip_detector/README.md
+++ b/non_catalog_apps/fake_chip_detector/README.md
@@ -8,23 +8,24 @@ reads the chip's factory ID register — the number burned into the die rather t
 package — names the part, and then asks the one question it cannot answer itself: is this what
 you bought?
 
-- **80 chips** in the database, 51 identified by an ID register and 29 by address alone. Every
+- **82 chips** in the database, 53 identified by an ID register and 29 by address alone. Every
   constant is taken from the manufacturer's datasheet and cited in `chip_db.c`.
 - **A report** written for a seller: plain statement first, why a factory ID cannot be forged
   second, register values last. Readable on the device, saved to
   `/ext/apps_data/fake_chip_detector/`.
 - **Wiring diagnosis** with live per-line detection — missing pull-up, line shorted to ground,
   SDA shorted to SCL, or the module plugged into the wrong header pins entirely.
-- **13 live tests.** An ID register is one byte and a byte can be copied; a working sensor
+- **14 live tests.** An ID register is one byte and a byte can be copied; a working sensor
   cannot. Breathe on an AHT or SHT, cover a BH1750, tip an MPU6050 or ADXL345, wave at an
   APDS9960, point an MLX90614 at your palm, watch a DS3231 tick, blink an SSD1306, turn a BNO055
-  through a figure-8, hold a hand in front of a VL6180X.
+  through a figure-8, wave an AK09911 through a field, hold a hand in front of a VL6180X.
 - **1-Wire scanning** on pin 17 with a real temperature conversion, so a DS18S20 sold as a
   DS18B20 is caught.
 - Tests can also be **loaded from the SD card as .fal plugins** — see [LIVE_TESTS.md](LIVE_TESTS.md).
 
 It refuses to overclaim: a chip with no ID register is reported as present, never as genuine; a
-device matching nothing is unidentified, not "fake"; a failed read is shown as a failure.
+device matching nothing is unidentified, not "fake"; a failed read is shown as a failure; and
+when more than one part fits what was read, it names them all rather than picking one.
 
 ## Wiring
 

--- a/non_catalog_apps/fake_chip_detector/SUPPORTED_CHIPS.md
+++ b/non_catalog_apps/fake_chip_detector/SUPPORTED_CHIPS.md
@@ -61,7 +61,7 @@ label claims.
 | **MMC5603** | Magnetometer | 0x30 | `0x39` | `0x10` | 8-bit | — |  |
 | **HMC5883L** | Magnetometer | 0x1E | `0x0A`<br>`0x0B`<br>`0x0C` | `0x48`<br>`0x34`<br>`0x33` | 8-bit<br>8-bit<br>8-bit | — | EOL since 2016, mostly fake |
 | **QMC5883L** | Magnetometer | 0x0D | `0x0D` | `0xFF` | 8-bit | — |  |
-| **QMC5883P** | Magnetometer | 0x2C | `0x00` | `0x80` | 8-bit | — |  |
+| **QMC5883P** | Magnetometer | 0x2C | `0x00` | `0x80` | 8-bit | Turn it through a field | GY-271 board, not a 5883L |
 | **AK09911** | Magnetometer | 0x0C, 0x0D | `0x00`<br>`0x01` | `0x48`<br>`0x05` | 8-bit<br>8-bit | Wave it through a field | RST must be high to answer |
 | **VL53L0X** | Laser rangefinder | 0x29 | `0xC0` | `0xEE` | 8-bit | — |  |
 | **VL53L1X** | Laser rangefinder | 0x29 | `0x010F` MODEL_ID<br>`0x0110` MODULE_TYPE | `0xEA`<br>`0xCC` | 8-bit<br>8-bit | — |  |

--- a/non_catalog_apps/fake_chip_detector/SUPPORTED_CHIPS.md
+++ b/non_catalog_apps/fake_chip_detector/SUPPORTED_CHIPS.md
@@ -18,25 +18,25 @@ do it. Generated from [`chip_db.c`](chip_db.c) — the app and this table cannot
 If your chip is missing, the app says so plainly rather than calling it a fake — see
 [Adding a chip](#adding-a-chip) below.
 
-## Chips with a factory ID register (51)
+## Chips with a factory ID register (53)
 
 These can be verified. A mismatch here is real evidence that the part is not what the
 label claims.
 
 | Chip | What it is | I2C address | Register | Expected | Width | Live test | Notes |
 |---|---|---|---|---|---|---|---|
-| **BNO055** | 9-axis IMU + fusion | 0x28, 0x29 | `0x00` CHIP_ID<br>`0x01` ACC_ID (BMA280)<br>`0x02` MAG_ID (BMM150)<br>`0x03` GYR_ID (BMG160) | `0xA0`<br>`0xFB`<br>`0x32`<br>`0x0F` | 8-bit<br>8-bit<br>8-bit<br>8-bit | Prove it finds north |  |
+| **BNO055** | 9-axis fusion IMU | 0x28, 0x29 | `0x00` CHIP_ID<br>`0x01` ACC_ID (BMA280)<br>`0x02` MAG_ID (BMM150)<br>`0x03` GYR_ID (BMG160) | `0xA0`<br>`0xFB`<br>`0x32`<br>`0x0F` | 8-bit<br>8-bit<br>8-bit<br>8-bit | Prove it finds north |  |
 | **BMP280** | Pressure sensor | 0x76, 0x77 | `0xD0` | `0x58` | 8-bit | — |  |
-| **BME280** | Press/temp/humidity | 0x76, 0x77 | `0xD0` | `0x60` | 8-bit | — |  |
+| **BME280** | Climate sensor | 0x76, 0x77 | `0xD0` | `0x60` | 8-bit | — |  |
 | **BMP180** | Pressure sensor | 0x77 | `0xD0` | `0x55` | 8-bit | — |  |
 | **BMP388** | Pressure sensor | 0x76, 0x77 | `0x00` | `0x50` | 8-bit | — |  |
 | **BMP390** | Pressure sensor | 0x76, 0x77 | `0x00` | `0x60` | 8-bit | — |  |
-| **BME680** | Air quality + climate | 0x76, 0x77 | `0xD0`<br>`0xF0` | `0x61`<br>`0x00` | 8-bit<br>8-bit | — |  |
-| **BME688** | Air quality + climate | 0x76, 0x77 | `0xD0`<br>`0xF0` | `0x61`<br>`0x01` | 8-bit<br>8-bit | — |  |
+| **BME680** | Gas + climate sensor | 0x76, 0x77 | `0xD0`<br>`0xF0` | `0x61`<br>`0x00` | 8-bit<br>8-bit | — |  |
+| **BME688** | Gas + climate sensor | 0x76, 0x77 | `0xD0`<br>`0xF0` | `0x61`<br>`0x01` | 8-bit<br>8-bit | — |  |
 | **DPS310** | Pressure sensor | 0x76, 0x77 | `0x0D` | `0x10` | 8-bit | — |  |
-| **CCS811** | Air quality (VOC) | 0x5A, 0x5B | `0x20` | `0x81` | 8-bit | — | EOL part, clones common |
-| **ENS160** | Air quality (VOC) | 0x52, 0x53 | `0x00`<br>`0x01` | `0x60`<br>`0x01` | 8-bit<br>8-bit | — |  |
-| **HDC1080** | Temp + humidity | 0x40 | `0xFE`<br>`0xFF` | `0x5449`<br>`0x1050` | 16-bit<br>16-bit | — |  |
+| **CCS811** | Air quality sensor | 0x5A, 0x5B | `0x20` | `0x81` | 8-bit | — | EOL part, clones common |
+| **ENS160** | Air quality sensor | 0x52, 0x53 | `0x00`<br>`0x01` | `0x60`<br>`0x01` | 8-bit<br>8-bit | — |  |
+| **HDC1080** | Humidity sensor | 0x40 | `0xFE`<br>`0xFF` | `0x5449`<br>`0x1050` | 16-bit<br>16-bit | — |  |
 | **MPU6050** | 6-axis IMU | 0x68, 0x69 | `0x75` | `0x68` | 8-bit | Tip it and watch gravity | TDK EOL, old stock |
 | **MPU6500** | 6-axis IMU | 0x68, 0x69 | `0x75` | `0x70` | 8-bit | Tip it and watch gravity | often sold as MPU9250 |
 | **MPU9250** | 9-axis IMU | 0x68, 0x69 | `0x75` | `0x71` | 8-bit | Tip it and watch gravity | TDK EOL, often faked |
@@ -61,14 +61,16 @@ label claims.
 | **MMC5603** | Magnetometer | 0x30 | `0x39` | `0x10` | 8-bit | — |  |
 | **HMC5883L** | Magnetometer | 0x1E | `0x0A`<br>`0x0B`<br>`0x0C` | `0x48`<br>`0x34`<br>`0x33` | 8-bit<br>8-bit<br>8-bit | — | EOL since 2016, mostly fake |
 | **QMC5883L** | Magnetometer | 0x0D | `0x0D` | `0xFF` | 8-bit | — |  |
+| **QMC5883P** | Magnetometer | 0x2C | `0x00` | `0x80` | 8-bit | — |  |
+| **AK09911** | Magnetometer | 0x0C, 0x0D | `0x00`<br>`0x01` | `0x48`<br>`0x05` | 8-bit<br>8-bit | Wave it through a field | RST must be high to answer |
 | **VL53L0X** | Laser rangefinder | 0x29 | `0xC0` | `0xEE` | 8-bit | — |  |
 | **VL53L1X** | Laser rangefinder | 0x29 | `0x010F` MODEL_ID<br>`0x0110` MODULE_TYPE | `0xEA`<br>`0xCC` | 8-bit<br>8-bit | — |  |
 | **VL6180X** | Laser rangefinder | 0x29 | `0x0000` | `0xB4` | 8-bit | Watch it measure |  |
 | **TCS34725** | Colour sensor | 0x29 | `0x92` | `0x44` | 8-bit | — |  |
 | **TSL2591** | Light sensor | 0x29 | `0xB2` | `0x50` | 8-bit | — |  |
-| **APDS9960** | Gesture + colour | 0x39 | `0x92` | `0xAB` | 8-bit | Wave your hand at it |  |
+| **APDS9960** | Gesture + RGB sensor | 0x39 | `0x92` | `0xAB` | 8-bit | Wave your hand at it |  |
 | **LTR-390UV** | UV + light sensor | 0x53 | `0x06` | `0xB0` (mask `0xF0`) | 8-bit | — |  |
-| **MAX30102** | Heart rate / SpO2 | 0x57 | `0xFF` | `0x15` | 8-bit | — | 0x11 here = MAX30100 relabel |
+| **MAX30102** | Pulse oximeter | 0x57 | `0xFF` | `0x15` | 8-bit | — | 0x11 here = MAX30100 relabel |
 | **INA226** | Current monitor | 0x40-0x4F | `0xFE`<br>`0xFF` | `0x5449`<br>`0x2260` | 16-bit<br>16-bit | — |  |
 | **INA260** | Current monitor | 0x40-0x4F | `0xFE`<br>`0xFF` | `0x5449`<br>`0x2270` | 16-bit<br>16-bit | — |  |
 | **INA228** | Current monitor | 0x40-0x4F | `0x3E` | `0x5449` | 16-bit | — |  |
@@ -93,17 +95,17 @@ ever exist, because asking the part to do its job is the one question left to as
 | **DS1307** | Real-time clock | 0x68 | — |  |
 | **PCF8563** | Real-time clock | 0x51 | — |  |
 | **SSD1306/SH1106** | OLED display | 0x3C, 0x3D | Make the screen blink | SH1106 fakes undetectable |
-| **AHT10/AHT20** | Temp + humidity | 0x38 | Breathe on it |  |
+| **AHT10/AHT20** | Humidity sensor | 0x38 | Breathe on it |  |
 | **BH1750** | Light sensor | 0x23, 0x5C | Cover it with your hand |  |
-| **SHT3x/SHT4x** | Temp + humidity | 0x44, 0x45 | Breathe on it | grade relabels undetectable |
+| **SHT3x/SHT4x** | Humidity sensor | 0x44, 0x45 | Breathe on it | grade relabels undetectable |
 | **SCD4x** | CO2 sensor | 0x62 | — |  |
-| **SGP30** | Air quality (VOC) | 0x58 | — |  |
-| **SGP40/41** | Air quality (VOC) | 0x59 | — |  |
+| **SGP30** | Air quality sensor | 0x58 | — |  |
+| **SGP40/41** | Air quality sensor | 0x59 | — |  |
 | **SCD30** | CO2 sensor | 0x61 | — |  |
-| **Si7021/HTU21D** | Temp + humidity | 0x40 | — |  |
+| **Si7021/HTU21D** | Humidity sensor | 0x40 | — |  |
 | **MLX90614** | IR thermometer | 0x5A | Point it at your hand |  |
 | **MLX90640** | Thermal camera | 0x33 | — |  |
-| **AS5600** | Magnetic angle | 0x36 | — |  |
+| **AS5600** | Magnetic angle sensor | 0x36 | — |  |
 | **MAX17048** | Battery fuel gauge | 0x36 | — |  |
 | **ADS1115** | ADC | 0x48-0x4B | — |  |
 | **INA219** | Current monitor | 0x40-0x4F | — |  |
@@ -117,7 +119,161 @@ ever exist, because asking the part to do its job is the one question left to as
 | **MS5611** | Pressure sensor | 0x76, 0x77 | — |  |
 | **VEML6070** | UV sensor | 0x38, 0x39 | — |  |
 | **MAX44009** | Light sensor | 0x4A, 0x4B | — |  |
-| **BNO085** | 9-axis IMU + fusion | 0x4A, 0x4B | — | SHTP protocol, no WHO_AM_I |
+| **BNO085** | 9-axis fusion IMU | 0x4A, 0x4B | — | SHTP protocol, no WHO_AM_I |
+
+## Addresses more than one chip answers on (50)
+
+**An I2C address does not name a part.** It is seven bits chosen by the manufacturer,
+and plenty of unrelated chips chose the same ones. This is why the app probes rather
+than looks up: for every candidate registered at the address that answered, it reads
+that candidate's ID registers and keeps the one with the most matches. A scan that
+reports one part at a crowded address has already ruled the others out.
+
+| Address | Chips that use it |
+|---|---|
+| `0x0D` | **QMC5883L** (Magnetometer), **AK09911** (Magnetometer) |
+| `0x18` | **BMI088 accel** (Accelerometer), **LIS3DH/2DH12** (Accelerometer) |
+| `0x19` | **BMI088 accel** (Accelerometer), **LIS3DH/2DH12** (Accelerometer) |
+| `0x1D` | **ADXL345/343** (Accelerometer), **ADXL355** (Accelerometer) |
+| `0x1E` | **LIS3MDL** (Magnetometer), **LIS2MDL** (Magnetometer), **HMC5883L** (Magnetometer) |
+| `0x20` | **MCP23017** (GPIO expander), **PCF8574** (GPIO expander) |
+| `0x21` | **MCP23017** (GPIO expander), **PCF8574** (GPIO expander) |
+| `0x22` | **MCP23017** (GPIO expander), **PCF8574** (GPIO expander) |
+| `0x23` | **BH1750** (Light sensor), **MCP23017** (GPIO expander), **PCF8574** (GPIO expander) |
+| `0x24` | **MCP23017** (GPIO expander), **PCF8574** (GPIO expander) |
+| `0x25` | **MCP23017** (GPIO expander), **PCF8574** (GPIO expander) |
+| `0x26` | **MCP23017** (GPIO expander), **PCF8574** (GPIO expander) |
+| `0x27` | **MCP23017** (GPIO expander), **PCF8574** (GPIO expander) |
+| `0x29` | **BNO055** (9-axis fusion IMU), **VL53L0X** (Laser rangefinder), **VL53L1X** (Laser rangefinder), **VL6180X** (Laser rangefinder), **TCS34725** (Colour sensor), **TSL2591** (Light sensor) |
+| `0x36` | **AS5600** (Magnetic angle sensor), **MAX17048** (Battery fuel gauge) |
+| `0x38` | **AHT10/AHT20** (Humidity sensor), **PCF8574A** (GPIO expander), **VEML6070** (UV sensor) |
+| `0x39` | **APDS9960** (Gesture + RGB sensor), **PCF8574A** (GPIO expander), **VEML6070** (UV sensor) |
+| `0x3C` | **SSD1306/SH1106** (OLED display), **PCF8574A** (GPIO expander) |
+| `0x3D` | **SSD1306/SH1106** (OLED display), **PCF8574A** (GPIO expander) |
+| `0x40` | **HDC1080** (Humidity sensor), **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **Si7021/HTU21D** (Humidity sensor), **INA219** (Current monitor), **PCA9685** (PWM / servo driver) |
+| `0x41` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **INA219** (Current monitor) |
+| `0x42` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **INA219** (Current monitor) |
+| `0x43` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **INA219** (Current monitor) |
+| `0x44` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **SHT3x/SHT4x** (Humidity sensor), **INA219** (Current monitor) |
+| `0x45` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **SHT3x/SHT4x** (Humidity sensor), **INA219** (Current monitor) |
+| `0x46` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **INA219** (Current monitor) |
+| `0x47` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **INA219** (Current monitor) |
+| `0x48` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **TMP117** (Temperature sensor), **ADS1115** (ADC), **INA219** (Current monitor) |
+| `0x49` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **TMP117** (Temperature sensor), **ADS1115** (ADC), **INA219** (Current monitor) |
+| `0x4A` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **TMP117** (Temperature sensor), **ADS1115** (ADC), **INA219** (Current monitor), **MAX44009** (Light sensor), **BNO085** (9-axis fusion IMU) |
+| `0x4B` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **TMP117** (Temperature sensor), **ADS1115** (ADC), **INA219** (Current monitor), **MAX44009** (Light sensor), **BNO085** (9-axis fusion IMU) |
+| `0x4C` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **INA219** (Current monitor) |
+| `0x4D` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **INA219** (Current monitor) |
+| `0x4E` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **INA219** (Current monitor) |
+| `0x4F` | **INA226** (Current monitor), **INA260** (Current monitor), **INA228** (Current monitor), **INA219** (Current monitor) |
+| `0x51` | **PCF8563** (Real-time clock), **AT24Cxx** (EEPROM memory) |
+| `0x52` | **ENS160** (Air quality sensor), **AT24Cxx** (EEPROM memory) |
+| `0x53` | **ENS160** (Air quality sensor), **ADXL345/343** (Accelerometer), **ADXL355** (Accelerometer), **LTR-390UV** (UV + light sensor), **AT24Cxx** (EEPROM memory) |
+| `0x57` | **MAX30102** (Pulse oximeter), **AT24Cxx** (EEPROM memory) |
+| `0x5A` | **CCS811** (Air quality sensor), **MLX90614** (IR thermometer) |
+| `0x5C` | **LPS22HB** (Pressure sensor), **LPS25HB** (Pressure sensor), **BH1750** (Light sensor) |
+| `0x5D` | **LPS22HB** (Pressure sensor), **LPS25HB** (Pressure sensor) |
+| `0x61` | **SCD30** (CO2 sensor), **MCP4725** (DAC) |
+| `0x62` | **SCD4x** (CO2 sensor), **MCP4725** (DAC) |
+| `0x68` | **MPU6050** (6-axis IMU), **MPU6500** (6-axis IMU), **MPU9250** (9-axis IMU), **MPU6886** (6-axis IMU), **ICM20948** (9-axis IMU), **ICM42605** (6-axis IMU), **ICM42688P** (6-axis IMU), **BMI160** (6-axis IMU), **BMI270** (6-axis IMU), **BMI088 gyro** (Gyroscope), **DS3231** (Real-time clock), **DS1307** (Real-time clock) |
+| `0x69` | **MPU6050** (6-axis IMU), **MPU6500** (6-axis IMU), **MPU9250** (9-axis IMU), **MPU6886** (6-axis IMU), **ICM20948** (9-axis IMU), **ICM42605** (6-axis IMU), **ICM42688P** (6-axis IMU), **BMI160** (6-axis IMU), **BMI270** (6-axis IMU), **BMI088 gyro** (Gyroscope) |
+| `0x6A` | **LSM6DS3** (6-axis IMU), **LSM6DS3TR-C** (6-axis IMU), **LSM6DSO/OX** (6-axis IMU), **LSM6DSV16X** (6-axis IMU), **QMI8658** (6-axis IMU) |
+| `0x6B` | **LSM6DS3** (6-axis IMU), **LSM6DS3TR-C** (6-axis IMU), **LSM6DSO/OX** (6-axis IMU), **LSM6DSV16X** (6-axis IMU), **QMI8658** (6-axis IMU) |
+| `0x76` | **BMP280** (Pressure sensor), **BME280** (Climate sensor), **BMP388** (Pressure sensor), **BMP390** (Pressure sensor), **BME680** (Gas + climate sensor), **BME688** (Gas + climate sensor), **DPS310** (Pressure sensor), **TCA9548A** (I2C multiplexer), **MS5611** (Pressure sensor) |
+| `0x77` | **BMP280** (Pressure sensor), **BME280** (Climate sensor), **BMP180** (Pressure sensor), **BMP388** (Pressure sensor), **BMP390** (Pressure sensor), **BME680** (Gas + climate sensor), **BME688** (Gas + climate sensor), **DPS310** (Pressure sensor), **TCA9548A** (I2C multiplexer), **MS5611** (Pressure sensor) |
+
+Reading this the other way: a chip whose neighbours all have ID registers is safe to
+identify by probing, and one sharing an address with an address-only part is not — the
+app will say DETECTED rather than guess between them.
+
+### Chips that can sit at more than one address (40)
+
+A pin on the module picks which. If a scan finds nothing, the pin is worth checking
+before the wiring is: the app searches every address in this list, but only the ones
+in it.
+
+| Chip | Addresses | Notes |
+|---|---|---|
+| **BNO055** | `0x28`, `0x29` |  |
+| **BMP280** | `0x76`, `0x77` |  |
+| **BME280** | `0x76`, `0x77` |  |
+| **BMP388** | `0x76`, `0x77` |  |
+| **BMP390** | `0x76`, `0x77` |  |
+| **BME680** | `0x76`, `0x77` |  |
+| **BME688** | `0x76`, `0x77` |  |
+| **DPS310** | `0x76`, `0x77` |  |
+| **CCS811** | `0x5A`, `0x5B` | EOL part, clones common |
+| **ENS160** | `0x52`, `0x53` |  |
+| **MPU6050** | `0x68`, `0x69` | TDK EOL, old stock |
+| **MPU6500** | `0x68`, `0x69` | often sold as MPU9250 |
+| **MPU9250** | `0x68`, `0x69` | TDK EOL, often faked |
+| **MPU6886** | `0x68`, `0x69` |  |
+| **ICM20948** | `0x68`, `0x69` |  |
+| **ICM42605** | `0x68`, `0x69` |  |
+| **ICM42688P** | `0x68`, `0x69` |  |
+| **BMI160** | `0x68`, `0x69` |  |
+| **BMI270** | `0x68`, `0x69` |  |
+| **BMI088 gyro** | `0x68`, `0x69` |  |
+| **BMI088 accel** | `0x18`, `0x19` |  |
+| **LSM6DS3** | `0x6A`, `0x6B` |  |
+| **LSM6DS3TR-C** | `0x6A`, `0x6B` |  |
+| **LSM6DSO/OX** | `0x6A`, `0x6B` | DSO and DSOX share the ID |
+| **LSM6DSV16X** | `0x6A`, `0x6B` |  |
+| **QMI8658** | `0x6A`, `0x6B` |  |
+| **LIS3DH/2DH12** | `0x18`, `0x19` | same ID as LIS2DH12 |
+| **ADXL345/343** | `0x53`, `0x1D` |  |
+| **ADXL355** | `0x1D`, `0x53` |  |
+| **LIS3MDL** | `0x1C`, `0x1E` |  |
+| **AK09911** | `0x0C`, `0x0D` | RST must be high to answer |
+| **LPS22HB** | `0x5C`, `0x5D` |  |
+| **LPS25HB** | `0x5C`, `0x5D` |  |
+| **SSD1306/SH1106** | `0x3C`, `0x3D` | SH1106 fakes undetectable |
+| **BH1750** | `0x23`, `0x5C` |  |
+| **SHT3x/SHT4x** | `0x44`, `0x45` | grade relabels undetectable |
+| **MS5611** | `0x76`, `0x77` |  |
+| **VEML6070** | `0x38`, `0x39` |  |
+| **MAX44009** | `0x4A`, `0x4B` |  |
+| **BNO085** | `0x4A`, `0x4B` | SHTP protocol, no WHO_AM_I |
+
+The BNO055 is the one to know about, because its datasheet and every breakout board
+disagree. Bosch BST-BNO055-DS000 Table 4-7 calls `0x29` the *default* and `0x28` the
+alternative, selected by the COM3 pin: HIGH gives `0x29`, LOW gives `0x28`. Boards tie
+COM3 low, so in practice almost every module answers on `0x28` and everyone calls that
+the default. Both are in the database.
+
+That same chip is also the clearest case of an address proving nothing: `0x29` is
+shared with three ST time-of-flight rangefinders and two light sensors, and the app
+separates them by reading four ID registers rather than one — CHIP_ID plus the
+BMA280, BMM150 and BMG160 sub-IDs, which clones get wrong far more often than they get
+CHIP_ID wrong.
+
+## Chips that can be strapped off the I2C bus (8)
+
+These parts have a pin that decides whether they speak I2C at all. Set the wrong way —
+by the board, by the factory, or by one glitch on the pad — the part is healthy, powered
+and completely invisible to any scan, because in that state it does not have an I2C
+address to answer on. An empty scan is not evidence that a chip is dead.
+
+| Chip | Pad | I2C needs it | Otherwise it speaks | After strapping |
+|---|---|---|---|---|
+| **BNO055** | `PS1` | LOW | UART | power-cycle it |
+| **BMP280** | `CSB` | HIGH | SPI | power-cycle it |
+| **BME280** | `CSB` | HIGH | SPI | power-cycle it |
+| **BME680** | `CSB` | HIGH | SPI | power-cycle it |
+| **LIS3DH/2DH12** | `CS` | HIGH | SPI | takes effect at once |
+| **LSM6DS3** | `CS` | HIGH | SPI | takes effect at once |
+| **ADXL345/343** | `CS` | HIGH | SPI | takes effect at once |
+| **AK09911** | `RST` | HIGH | nothing — it is held off | takes effect at once |
+
+The last column is not a detail. A latched pin is sampled at reset and nowhere else, so
+strapping the pad and rescanning changes nothing and looks like proof the part is
+broken. Bosch put it plainly for the BMP280, BME280 and BME680: once `CSB` has been
+pulled down even once, *"the I2C interface is disabled until the next power-on-reset"*.
+
+The list is short because a row that could not be checked against a datasheet is not
+here. A wrong entry would send someone to tie a pin the wrong way round, which is worse
+than no entry at all. Address-select pins are deliberately excluded: the sweep covers
+`0x08`-`0x77`, so they cannot hide a part.
 
 ## 1-Wire parts (15)
 
@@ -135,10 +291,10 @@ rather than mere presence.
 | Family code | Part | What it is | Measured |
 |---|---|---|---|
 | `0x01` | **DS1990A/DS2401** | Serial number key | — |
-| `0x04` | **DS2404** | Clock + memory | — |
+| `0x04` | **DS2404** | Clock + memory chip | — |
 | `0x05` | **DS2405** | Addressable switch | — |
 | `0x10` | **DS18S20** | Temperature sensor | temperature |
-| `0x1D` | **DS2423** | RAM + counter | — |
+| `0x1D` | **DS2423** | RAM + counter chip | — |
 | `0x20` | **DS2450** | 4-channel ADC | — |
 | `0x22` | **DS1822** | Temperature sensor | temperature |
 | `0x26` | **DS2438** | Battery monitor | — |

--- a/non_catalog_apps/fake_chip_detector/application.fam
+++ b/non_catalog_apps/fake_chip_detector/application.fam
@@ -7,7 +7,7 @@ App(
     stack_size=4 * 1024,
     fap_icon="icons/fake_chip_detector_10px.png",
     fap_category="GPIO",
-    fap_version="0.7",
+    fap_version="0.8",
     fap_author="hleserg",
     fap_description="Check whether an I2C sensor really is the chip it was sold as, before you solder it in.",
 )

--- a/non_catalog_apps/fake_chip_detector/application.fam
+++ b/non_catalog_apps/fake_chip_detector/application.fam
@@ -7,7 +7,7 @@ App(
     stack_size=4 * 1024,
     fap_icon="icons/fake_chip_detector_10px.png",
     fap_category="GPIO",
-    fap_version="0.8",
+    fap_version="0.10",
     fap_author="hleserg",
     fap_description="Check whether an I2C sensor really is the chip it was sold as, before you solder it in.",
 )

--- a/non_catalog_apps/fake_chip_detector/chip_db.c
+++ b/non_catalog_apps/fake_chip_detector/chip_db.c
@@ -99,7 +99,13 @@ static const IdCheck qmc5883l_checks[] = {{0x0D, 0xFF, M8, false, false}};
 // default value is 80H." Section 5.4: "The default I2C address for QMC5883P is
 // 2CH." Not the same part as the QMC5883L above and not at the same address --
 // a GY-271 board photographed at 0x2C is a QMC5883P candidate, and this row is
-// what would confirm it. Nobody has read 0x2C on one yet.
+// what confirms it. One did, on 9 Sep 2026: a blue board silkscreened GY-271
+// answered at 0x2C and read 0x80 at register 0x00, which is this row and no
+// other. The note it carries comes from that board. GY-271 is the module name
+// the HMC5883L made famous and the number people search for; the die inside is
+// now usually a QST part, and a P is not register-compatible with either the
+// HMC5883L or the QMC5883L, so a driver written for the number on the silkscreen
+// will not talk to it.
 static const IdCheck qmc5883p_checks[] = {{0x00, 0x80, M8, false, false}};
 // WIA1 at 0x00 is the AKM company code and WIA2 at 0x01 the device code, both
 // fixed. The two values are the one thing in this row that does NOT come from a
@@ -219,7 +225,14 @@ static const ChipEntry chip_db[] = {
      3,
      "EOL since 2016, mostly fake"},
     {"QMC5883L", "Magnetometer", {0x0D, 0xFF}, 0, 0, qmc5883l_checks, 1, NULL},
-    {"QMC5883P", "Magnetometer", {0x2C, 0xFF}, 0, 0, qmc5883p_checks, 1, NULL},
+    {"QMC5883P",
+     "Magnetometer",
+     {0x2C, 0xFF},
+     0,
+     0,
+     qmc5883p_checks,
+     1,
+     "GY-271 board, not a 5883L"},
     {"AK09911",
      "Magnetometer",
      {0x0C, 0x0D, 0xFF},

--- a/non_catalog_apps/fake_chip_detector/chip_db.c
+++ b/non_catalog_apps/fake_chip_detector/chip_db.c
@@ -2,6 +2,7 @@
 #include "i2c_worker.h"
 
 #include <furi.h>
+#include <string.h>
 
 // Every constant below was checked against the manufacturer datasheet or the
 // vendor's own driver. A wrong value here makes the app accuse a genuine
@@ -87,7 +88,34 @@ static const IdCheck hmc5883l_checks[] = {
     {0x0B, 0x34, M8, false, false},
     {0x0C, 0x33, M8, false, false},
 };
+// One read of one register, and the register is 0xFF on more than this part.
+// It stays because a QMC5883L has nothing better to offer -- 0x0D is the only
+// thing in its map that is fixed -- but it is the weakest signature in this
+// table, and the AK09911 below shares one of its addresses. Which one wins is
+// settled by chip_db_identify on the number of registers each had to get
+// right, so nothing here depends on the order these two rows are written in.
 static const IdCheck qmc5883l_checks[] = {{0x0D, 0xFF, M8, false, false}};
+// QST QMC5883P Rev. E section 9.2.1: "Register 00H stores the chip ID. The
+// default value is 80H." Section 5.4: "The default I2C address for QMC5883P is
+// 2CH." Not the same part as the QMC5883L above and not at the same address --
+// a GY-271 board photographed at 0x2C is a QMC5883P candidate, and this row is
+// what would confirm it. Nobody has read 0x2C on one yet.
+static const IdCheck qmc5883p_checks[] = {{0x00, 0x80, M8, false, false}};
+// WIA1 at 0x00 is the AKM company code and WIA2 at 0x01 the device code, both
+// fixed. The two values are the one thing in this row that does NOT come from a
+// datasheet read for it: AKM publishes the register map only in the full
+// MS1526-E-01, which would not download here, and the ShortDatasheet-E-00 that
+// did has no register section. They are the values issue #38 cites from
+// MS1526-E-01 sections 7.1.4 and 8.3.1, and they are also what a purple
+// AK09911C breakout answered on 8 Sep 2026, reading 48 05 20 00 across
+// 0x00-0x03. Two independent sources agreeing, neither of them read here.
+//
+// That same board is why this row exists: it was being reported as a GENUINE
+// QMC5883L, because 0x0D on it reads 0xFF too.
+static const IdCheck ak09911_checks[] = {
+    {0x00, 0x48, M8, false, false},
+    {0x01, 0x05, M8, false, false},
+};
 
 /* --- light / proximity / ToF --- */
 // ST time-of-flight parts index their registers with a 16-bit address.
@@ -124,26 +152,26 @@ static const IdCheck lps25hb_checks[] = {{0x0F, 0xBD, M8, false, false}};
 static const IdCheck cst816s_checks[] = {{0xA7, 0xB4, M8, false, false}};
 
 static const ChipEntry chip_db[] = {
-    /* name, addrs, range_lo, range_hi, checks, count, note */
-    {"BNO055", "9-axis IMU + fusion", {0x28, 0x29, 0xFF}, 0, 0, bno055_checks, 4, NULL},
+    /* name, kind, addrs, range_lo, range_hi, checks, count, note */
+    {"BNO055", "9-axis fusion IMU", {0x28, 0x29, 0xFF}, 0, 0, bno055_checks, 4, NULL},
     {"BMP280", "Pressure sensor", {0x76, 0x77, 0xFF}, 0, 0, bmp280_checks, 1, NULL},
-    {"BME280", "Press/temp/humidity", {0x76, 0x77, 0xFF}, 0, 0, bme280_checks, 1, NULL},
+    {"BME280", "Climate sensor", {0x76, 0x77, 0xFF}, 0, 0, bme280_checks, 1, NULL},
     {"BMP180", "Pressure sensor", {0x77, 0xFF}, 0, 0, bmp180_checks, 1, NULL},
     {"BMP388", "Pressure sensor", {0x76, 0x77, 0xFF}, 0, 0, bmp388_checks, 1, NULL},
     {"BMP390", "Pressure sensor", {0x76, 0x77, 0xFF}, 0, 0, bmp390_checks, 1, NULL},
-    {"BME680", "Air quality + climate", {0x76, 0x77, 0xFF}, 0, 0, bme680_checks, 2, NULL},
-    {"BME688", "Air quality + climate", {0x76, 0x77, 0xFF}, 0, 0, bme688_checks, 2, NULL},
+    {"BME680", "Gas + climate sensor", {0x76, 0x77, 0xFF}, 0, 0, bme680_checks, 2, NULL},
+    {"BME688", "Gas + climate sensor", {0x76, 0x77, 0xFF}, 0, 0, bme688_checks, 2, NULL},
     {"DPS310", "Pressure sensor", {0x76, 0x77, 0xFF}, 0, 0, dps310_checks, 1, NULL},
     {"CCS811",
-     "Air quality (VOC)",
+     "Air quality sensor",
      {0x5A, 0x5B, 0xFF},
      0,
      0,
      ccs811_checks,
      1,
      "EOL part, clones common"},
-    {"ENS160", "Air quality (VOC)", {0x52, 0x53, 0xFF}, 0, 0, ens160_checks, 2, NULL},
-    {"HDC1080", "Temp + humidity", {0x40, 0xFF}, 0, 0, hdc1080_checks, 2, NULL},
+    {"ENS160", "Air quality sensor", {0x52, 0x53, 0xFF}, 0, 0, ens160_checks, 2, NULL},
+    {"HDC1080", "Humidity sensor", {0x40, 0xFF}, 0, 0, hdc1080_checks, 2, NULL},
 
     {"MPU6050", "6-axis IMU", {0x68, 0x69, 0xFF}, 0, 0, mpu6050_checks, 1, "TDK EOL, old stock"},
     {"MPU6500", "6-axis IMU", {0x68, 0x69, 0xFF}, 0, 0, mpu6500_checks, 1, "often sold as MPU9250"},
@@ -191,16 +219,25 @@ static const ChipEntry chip_db[] = {
      3,
      "EOL since 2016, mostly fake"},
     {"QMC5883L", "Magnetometer", {0x0D, 0xFF}, 0, 0, qmc5883l_checks, 1, NULL},
+    {"QMC5883P", "Magnetometer", {0x2C, 0xFF}, 0, 0, qmc5883p_checks, 1, NULL},
+    {"AK09911",
+     "Magnetometer",
+     {0x0C, 0x0D, 0xFF},
+     0,
+     0,
+     ak09911_checks,
+     2,
+     "RST must be high to answer"},
 
     {"VL53L0X", "Laser rangefinder", {0x29, 0xFF}, 0, 0, vl53l0x_checks, 1, NULL},
     {"VL53L1X", "Laser rangefinder", {0x29, 0xFF}, 0, 0, vl53l1x_checks, 2, NULL},
     {"VL6180X", "Laser rangefinder", {0x29, 0xFF}, 0, 0, vl6180x_checks, 1, NULL},
     {"TCS34725", "Colour sensor", {0x29, 0xFF}, 0, 0, tcs34725_checks, 1, NULL},
     {"TSL2591", "Light sensor", {0x29, 0xFF}, 0, 0, tsl2591_checks, 1, NULL},
-    {"APDS9960", "Gesture + colour", {0x39, 0xFF}, 0, 0, apds9960_checks, 1, NULL},
+    {"APDS9960", "Gesture + RGB sensor", {0x39, 0xFF}, 0, 0, apds9960_checks, 1, NULL},
     {"LTR-390UV", "UV + light sensor", {0x53, 0xFF}, 0, 0, ltr390_checks, 1, NULL},
     {"MAX30102",
-     "Heart rate / SpO2",
+     "Pulse oximeter",
      {0x57, 0xFF},
      0,
      0,
@@ -228,10 +265,10 @@ static const ChipEntry chip_db[] = {
      NULL,
      0,
      "SH1106 fakes undetectable"},
-    {"AHT10/AHT20", "Temp + humidity", {0x38, 0xFF}, 0, 0, NULL, 0, NULL},
+    {"AHT10/AHT20", "Humidity sensor", {0x38, 0xFF}, 0, 0, NULL, 0, NULL},
     {"BH1750", "Light sensor", {0x23, 0x5C, 0xFF}, 0, 0, NULL, 0, NULL},
     {"SHT3x/SHT4x",
-     "Temp + humidity",
+     "Humidity sensor",
      {0x44, 0x45, 0xFF},
      0,
      0,
@@ -239,13 +276,13 @@ static const ChipEntry chip_db[] = {
      0,
      "grade relabels undetectable"},
     {"SCD4x", "CO2 sensor", {0x62, 0xFF}, 0, 0, NULL, 0, NULL},
-    {"SGP30", "Air quality (VOC)", {0x58, 0xFF}, 0, 0, NULL, 0, NULL},
-    {"SGP40/41", "Air quality (VOC)", {0x59, 0xFF}, 0, 0, NULL, 0, NULL},
+    {"SGP30", "Air quality sensor", {0x58, 0xFF}, 0, 0, NULL, 0, NULL},
+    {"SGP40/41", "Air quality sensor", {0x59, 0xFF}, 0, 0, NULL, 0, NULL},
     {"SCD30", "CO2 sensor", {0x61, 0xFF}, 0, 0, NULL, 0, NULL},
-    {"Si7021/HTU21D", "Temp + humidity", {0x40, 0xFF}, 0, 0, NULL, 0, NULL},
+    {"Si7021/HTU21D", "Humidity sensor", {0x40, 0xFF}, 0, 0, NULL, 0, NULL},
     {"MLX90614", "IR thermometer", {0x5A, 0xFF}, 0, 0, NULL, 0, NULL},
     {"MLX90640", "Thermal camera", {0x33, 0xFF}, 0, 0, NULL, 0, NULL},
-    {"AS5600", "Magnetic angle", {0x36, 0xFF}, 0, 0, NULL, 0, NULL},
+    {"AS5600", "Magnetic angle sensor", {0x36, 0xFF}, 0, 0, NULL, 0, NULL},
     {"MAX17048", "Battery fuel gauge", {0x36, 0xFF}, 0, 0, NULL, 0, NULL},
     {"ADS1115", "ADC", {0xFF}, 0x48, 0x4B, NULL, 0, NULL},
     {"INA219", "Current monitor", {0xFF}, 0x40, 0x4F, NULL, 0, NULL},
@@ -259,14 +296,7 @@ static const ChipEntry chip_db[] = {
     {"MS5611", "Pressure sensor", {0x76, 0x77, 0xFF}, 0, 0, NULL, 0, NULL},
     {"VEML6070", "UV sensor", {0x38, 0x39, 0xFF}, 0, 0, NULL, 0, NULL},
     {"MAX44009", "Light sensor", {0x4A, 0x4B, 0xFF}, 0, 0, NULL, 0, NULL},
-    {"BNO085",
-     "9-axis IMU + fusion",
-     {0x4A, 0x4B, 0xFF},
-     0,
-     0,
-     NULL,
-     0,
-     "SHTP protocol, no WHO_AM_I"},
+    {"BNO085", "9-axis fusion IMU", {0x4A, 0x4B, 0xFF}, 0, 0, NULL, 0, "SHTP protocol, no WHO_AM_I"},
 };
 
 #define CHIP_DB_COUNT (sizeof(chip_db) / sizeof(chip_db[0]))
@@ -335,61 +365,101 @@ static int32_t chip_try_candidate(const ChipEntry* chip, uint8_t addr7, IdReadRe
     return all_reads_ok ? matches : -1;
 }
 
+size_t chip_db_no_id_at(uint8_t addr7, const ChipEntry** out, size_t max) {
+    size_t n = 0;
+    for(size_t i = 0; i < CHIP_DB_COUNT; i++) {
+        const ChipEntry* chip = &chip_db[i];
+        if(chip->checks != NULL || !chip_has_addr(chip, addr7)) continue;
+        if(out && n < max) out[n] = chip;
+        n++;
+    }
+    return n;
+}
+
 void chip_db_identify(uint8_t addr7, ChipIdentification* out) {
+    // Zero here means VerdictNotChecked, not VerdictGenuine. Every return below
+    // sets a verdict of its own, so this only ever shows if someone later adds
+    // a path that forgets to -- and then it says "not checked" rather than
+    // calling an unexamined part real.
     memset(out, 0, sizeof(*out));
 
-    const ChipEntry* no_id_candidate = NULL;
+    const ChipEntry* no_id_first = NULL;
+    const size_t no_id_count = chip_db_no_id_at(addr7, &no_id_first, 1);
+
     const ChipEntry* best_chip = NULL;
     IdReadResult best_reads[CHIP_MAX_CHECKS] = {0};
     uint8_t best_read_count = 0;
-    int32_t best_matches = -1; // -1 = every read of every candidate failed
+    // -2, not -1, because -1 is a real score: chip_try_candidate returns it
+    // when a read failed. Starting at -1 meant the first such candidate never
+    // beat the initial value, so best_chip stayed NULL and the verdict below
+    // shipped with read_count == 0 -- the detail screen of a part that answers
+    // its address and nothing else was blank, which is the one case where the
+    // registers it refused to answer are the whole story.
+    int32_t best_matches = -2;
+    bool best_full = false;
+    bool best_tied = false;
+    uint8_t best_tie_count = 1;
+
+    bool any_read_attempted = false;
     bool any_read_ok = false;
 
     for(size_t i = 0; i < CHIP_DB_COUNT; i++) {
         const ChipEntry* chip = &chip_db[i];
-        if(!chip_has_addr(chip, addr7)) continue;
+        if(chip->checks == NULL || !chip_has_addr(chip, addr7)) continue;
 
-        if(chip->checks == NULL) {
-            if(!no_id_candidate) no_id_candidate = chip;
-            continue;
-        }
-
+        const uint8_t count = chip->check_count < CHIP_MAX_CHECKS ? chip->check_count :
+                                                                    CHIP_MAX_CHECKS;
         IdReadResult reads[CHIP_MAX_CHECKS];
-        int32_t matches = chip_try_candidate(chip, addr7, reads);
-        for(uint8_t r = 0; r < chip->check_count && r < CHIP_MAX_CHECKS; r++) {
+        const int32_t matches = chip_try_candidate(chip, addr7, reads);
+        for(uint8_t r = 0; r < count; r++) {
+            any_read_attempted = true;
             if(reads[r].read_ok) any_read_ok = true;
         }
 
-        if(matches == (int32_t)chip->check_count) {
-            out->chip = chip;
-            out->verdict = VerdictGenuine;
-            memcpy(out->reads, reads, sizeof(reads));
-            out->read_count = chip->check_count;
-            return;
+        const bool full = (count > 0 && matches == (int32_t)count);
+
+        // Two full matches at one address are decided by how many registers
+        // each one had to get right, never by which row was typed first. At
+        // 0x0D the AK09911 answers two ID registers taken from its datasheet,
+        // while the QMC5883L candidate is a single read of a register that is
+        // reserved on both parts and comes back 0xFF either way. Ordering the
+        // table differently must not change what a board is called, and adding
+        // a row must not quietly rename one.
+        bool better;
+        if(full != best_full) {
+            better = full; // any full match beats any partial one
+        } else if(full) {
+            better = count > best_read_count;
+        } else {
+            better = matches > best_matches;
         }
-        if(matches > best_matches) {
+
+        // ponytail: equal-length full matches are called ambiguous rather than
+        // scored further. Weighing a wide unique value against a narrow common
+        // one would separate them, and wants a per-check weight in the table
+        // to do honestly. No address in the database needs it yet.
+        if(full && best_full && count == best_read_count && !better) {
+            best_tied = true;
+            best_tie_count++;
+            continue;
+        }
+
+        if(better) {
+            best_full = full;
             best_matches = matches;
             best_chip = chip;
-            memcpy(best_reads, reads, sizeof(reads));
-            best_read_count = chip->check_count;
+            best_read_count = count;
+            best_tied = false;
+            best_tie_count = 1;
+            memcpy(best_reads, reads, sizeof(best_reads));
         }
     }
 
-    // The device ACKed its address but no register read ever succeeded.
-    // Report that honestly instead of guessing at a no-ID chip.
-    if(!any_read_ok && (best_chip != NULL || no_id_candidate == NULL)) {
-        out->chip = best_chip;
-        out->verdict = VerdictNoAnswer;
-        memcpy(out->reads, best_reads, sizeof(best_reads));
-        out->read_count = best_read_count;
-        return;
-    }
-
-    if(best_chip == NULL && no_id_candidate == NULL) {
+    if(best_chip == NULL && no_id_count == 0) {
         // Address is unknown: probe the common WHO_AM_I locations so the user
         // has raw bytes to search for.
         static const uint8_t probe_regs[] = {0x00, 0x0F, 0x75, 0xD0};
-        out->verdict = VerdictUnknown;
+        bool probe_ok = false;
         for(size_t i = 0; i < sizeof(probe_regs) && out->read_count < CHIP_MAX_CHECKS; i++) {
             IdReadResult* r = &out->reads[out->read_count];
             uint8_t byte = 0;
@@ -397,41 +467,74 @@ void chip_db_identify(uint8_t addr7, ChipIdentification* out) {
             r->has_expected = false;
             r->read_ok = i2c_worker_read_reg(addr7, probe_regs[i], &byte, I2C_REG_TIMEOUT_MS);
             r->actual = byte;
+            if(r->read_ok) probe_ok = true;
             out->read_count++;
         }
-        return;
-    }
-
-    if(no_id_candidate && best_matches <= 0) {
-        // Reads worked but matched nothing, and a known chip without an ID
-        // register lives here (DS3231 at 0x68, SSD1306 at 0x3C). Presence is
-        // all we can honestly claim — never GENUINE without an ID to check.
-        out->chip = no_id_candidate;
-        out->verdict = VerdictDetectedNoId;
-        memcpy(out->reads, best_reads, sizeof(best_reads));
-        out->read_count = best_read_count;
+        // "Not in the database" and "would not talk" are different faults with
+        // different fixes, and only the first is about the database. Sending
+        // someone to look up bytes that were never read is the worse of the two
+        // mistakes, so an address that answered nothing says so.
+        out->verdict = probe_ok ? VerdictUnknown : VerdictNoAnswer;
         return;
     }
 
     memcpy(out->reads, best_reads, sizeof(best_reads));
     out->read_count = best_read_count;
 
+    if(any_read_attempted && !any_read_ok) {
+        // The device ACKed its address and then answered no register at all.
+        // It is deliberately left unnamed: a part that will not read has
+        // identified itself as nothing, and the failed registers below are the
+        // only evidence there is.
+        out->chip = NULL;
+        out->verdict = VerdictNoAnswer;
+        return;
+    }
+
+    if(best_full) {
+        // A tie survived to here, so two parts each answered the same number of
+        // ID registers correctly and both are telling the truth about
+        // themselves. Naming either would be a coin toss printed as a reading.
+        out->chip = best_tied ? NULL : best_chip;
+        out->verdict = best_tied ? VerdictAmbiguous : VerdictGenuine;
+        out->candidates = best_tied ? best_tie_count : 0;
+        return;
+    }
+
     if(best_matches > 0) {
         // Some of a known chip's IDs match and the rest do not. A genuine part
         // has all of them, so this is real evidence of a counterfeit.
         out->chip = best_chip;
         out->verdict = VerdictWrongChip;
-    } else {
-        // Nothing matched at all. That is far more often a chip missing from
-        // the database than a fake, so do not accuse it — show the bytes and
-        // let the user look them up.
-        out->chip = NULL;
-        out->verdict = VerdictNoMatch;
+        return;
     }
+
+    // Reads worked but matched nothing, and a known chip without an ID register
+    // lives here. Presence is all we can honestly claim -- never GENUINE
+    // without an ID to check, and never a name when more than one part fits.
+    if(no_id_count == 1) {
+        out->chip = no_id_first;
+        out->verdict = VerdictDetectedNoId;
+        return;
+    }
+    if(no_id_count > 1) {
+        out->chip = NULL;
+        out->verdict = VerdictAmbiguous;
+        out->candidates = no_id_count > UINT8_MAX ? UINT8_MAX : (uint8_t)no_id_count;
+        return;
+    }
+
+    // Nothing matched at all. That is far more often a chip missing from the
+    // database than a fake, so do not accuse it -- show the bytes and let the
+    // user look them up.
+    out->chip = NULL;
+    out->verdict = VerdictNoMatch;
 }
 
 const char* chip_verdict_str(ChipVerdict verdict) {
     switch(verdict) {
+    case VerdictNotChecked:
+        return "NOT CHECKED";
     case VerdictGenuine:
         return "GENUINE";
     case VerdictWrongChip:
@@ -444,6 +547,8 @@ const char* chip_verdict_str(ChipVerdict verdict) {
         return "UNKNOWN";
     case VerdictNoAnswer:
         return "NO ANSWER";
+    case VerdictAmbiguous:
+        return "SEVERAL POSSIBLE";
     default:
         return "?";
     }
@@ -451,6 +556,8 @@ const char* chip_verdict_str(ChipVerdict verdict) {
 
 const char* chip_verdict_headline(ChipVerdict verdict) {
     switch(verdict) {
+    case VerdictNotChecked:
+        return "NOT CHECKED";
     case VerdictGenuine:
         return "GENUINE";
     case VerdictWrongChip:
@@ -463,6 +570,8 @@ const char* chip_verdict_headline(ChipVerdict verdict) {
         return "UNKNOWN";
     case VerdictNoAnswer:
         return "NO ANSWER";
+    case VerdictAmbiguous:
+        return "AMBIGUOUS";
     default:
         return "?";
     }
@@ -473,6 +582,10 @@ const char* chip_verdict_headline(ChipVerdict verdict) {
 // imply it compared anything to a label — it asks the user to do that.
 void chip_verdict_explain(ChipVerdict verdict, const char** line1, const char** line2) {
     switch(verdict) {
+    case VerdictNotChecked:
+        *line1 = "Nothing was checked yet.";
+        *line2 = "This should not appear.";
+        break;
     case VerdictGenuine:
         *line1 = "All ID registers match.";
         *line2 = "Does the label agree?";
@@ -493,6 +606,10 @@ void chip_verdict_explain(ChipVerdict verdict, const char** line1, const char** 
         *line1 = "It answers, reads fail.";
         *line2 = "Check pull-ups and wires.";
         break;
+    case VerdictAmbiguous:
+        *line1 = "More than one part fits.";
+        *line2 = "Nothing tells them apart.";
+        break;
     default:
         *line1 = "Address not in database.";
         *line2 = "Raw bytes are in details.";
@@ -500,12 +617,20 @@ void chip_verdict_explain(ChipVerdict verdict, const char** line1, const char** 
     }
 }
 
+// Ambiguous belongs here for the same reason DetectedNoId does: the address is
+// populated and not one byte read from it is evidence of anything wrong. It is
+// a weaker answer than either of the others, never a worse one, and routing it
+// down the "NOT YOURS" path would turn "this tool cannot tell two real parts
+// apart" into an accusation aimed at whoever sold the board.
 bool chip_verdict_is_good(ChipVerdict verdict) {
-    return verdict == VerdictGenuine || verdict == VerdictDetectedNoId;
+    return verdict == VerdictGenuine || verdict == VerdictDetectedNoId ||
+           verdict == VerdictAmbiguous;
 }
 
 const char* chip_verdict_short_str(ChipVerdict verdict) {
     switch(verdict) {
+    case VerdictNotChecked:
+        return "not checked";
     case VerdictGenuine:
         return "GENUINE";
     case VerdictWrongChip:
@@ -518,6 +643,8 @@ const char* chip_verdict_short_str(ChipVerdict verdict) {
         return "unknown";
     case VerdictNoAnswer:
         return "silent";
+    case VerdictAmbiguous:
+        return "ambiguous";
     default:
         return "?";
     }
@@ -526,4 +653,94 @@ const char* chip_verdict_short_str(ChipVerdict verdict) {
 const ChipEntry* chip_db_get(size_t index) {
     if(index >= CHIP_DB_COUNT) return NULL;
     return &chip_db[index];
+}
+
+// Pins that take a healthy part off the I2C bus. Same rule as the ID table
+// above, and it matters more here: a wrong `i2c_high` sends someone to strap a
+// pin the wrong way round, so a row nobody could verify is a row that is not
+// here. Quotes are from the datasheet named on each line.
+//
+// Two things deliberately absent. Address-select pins (AD0, ADR, SDO used as
+// an address bit) are not mode pins -- the sweep covers 0x08-0x77, so they
+// cannot hide anything, and listing them would have the screen cry wolf. And
+// the MPU6050 has no SPI at all; only the MPU6500/9250 siblings do.
+//
+// Still to verify before adding: BMP388, BMP390, BME688, BMI160, BMI270,
+// BMI088, MPU6500, MPU9250, MPU6886, ICM20948, ICM42605, ICM42688P,
+// LSM6DS3TR-C, LSM6DSO/OX, LSM6DSV16X, LIS3MDL, LIS2MDL, LPS22HB, LPS25HB,
+// ADXL355, and XSHUT on the VL53/VL6180X family.
+static const ChipModePin chip_mode_pins[] = {
+    // Bosch BST-BNO055-DS000 Table 4-4: PS1.PS0 = 0b00 is I2C, 0b10 is UART.
+    // Table 4-5: in UART mode COM2 (the SCL pad) becomes Tx and COM3 (the ADR
+    // pad) becomes Rx, so the part has no I2C address at all. The PS pins are
+    // read at reset, and the datasheet forbids leaving them floating.
+    {"BNO055", "PS1", ModePinProtocol, ModeAltUart, false, true},
+
+    // Bosch BST-BMP280-DS001, BST-BME280-DS002 and BME680 all carry the same
+    // sentence: "If CSB is connected to VDDIO, the I2C interface is active. If
+    // CSB is pulled down, the SPI interface is activated. After CSB has been
+    // pulled down once (regardless of whether any clock cycle occurred), the
+    // I2C interface is disabled until the next power-on-reset." One glitch on
+    // that pad is therefore permanent until the rail is cycled.
+    {"BMP280", "CSB", ModePinProtocol, ModeAltSpi, true, true},
+    {"BME280", "CSB", ModePinProtocol, ModeAltSpi, true, true},
+    {"BME680", "CSB", ModePinProtocol, ModeAltSpi, true, true},
+
+    // ST LIS3DH: "When using the I2C, CS must be tied high." Sampled live
+    // rather than latched, so raising the pad is enough on its own.
+    {"LIS3DH/2DH12", "CS", ModePinProtocol, ModeAltSpi, true, false},
+
+    // ST LSM6DS3 pin table, pin 12 CS: "I2C/SPI mode selection (1: SPI idle
+    // mode / I2C communication enabled; 0: SPI communication mode / I2C
+    // disabled)".
+    {"LSM6DS3", "CS", ModePinProtocol, ModeAltSpi, true, false},
+
+    // ADI ADXL345: "I2C mode is enabled if the CS pin is tied high to VDD I/O.
+    // The CS pin should always be tied high to VDD I/O."
+    {"ADXL345/343", "CS", ModePinProtocol, ModeAltSpi, true, false},
+
+    // AKM AK09911 ShortDatasheet-E-00 section 6.2: "(3) Reset pin (RSTN) --
+    // AK09911 is reset by Reset pin. When Reset pin is not used, connect to
+    // VID." The pin table puts RSTN in the VID domain, and the reset-current
+    // figure IDD4 is specified with "RSTN pin = 'L'", which is what makes the
+    // low the asserted level and the high the one this app needs.
+    //
+    // Held low the part is in reset and acknowledges nothing, which on a sweep
+    // looks exactly like an empty bus. A purple AK09911C breakout brings RST
+    // out to a pad with no pull-up on it, so a module wired VCC/GND/SDA/SCL and
+    // nothing else ships in that state and scans as absent.
+    //
+    // Nothing is latched -- reset is held, not sampled -- so raising the pad is
+    // enough on its own, and there is no moment where letting go is safe. This
+    // is the first row of its kind here: the XSHUT/RES/EN screen has been
+    // giving advice with no verified part behind it since it was written.
+    //
+    // The CAD pad on the same board is deliberately not here. Same datasheet,
+    // slave address table: CAD to VSS is 0001100 and CAD to VDD is 0001101, so
+    // it picks between 0x0C and 0x0D and the sweep covers both. An address pin
+    // cannot hide a part from this app.
+    {"AK09911", "RST", ModePinEnable, ModeAltOff, true, false},
+};
+
+#define CHIP_MODE_PIN_COUNT (sizeof(chip_mode_pins) / sizeof(chip_mode_pins[0]))
+
+const ChipModePin* chip_mode_pin_for(const char* chip_name) {
+    if(!chip_name) return NULL;
+    for(size_t i = 0; i < CHIP_MODE_PIN_COUNT; i++) {
+        if(strcmp(chip_mode_pins[i].chip, chip_name) == 0) return &chip_mode_pins[i];
+    }
+    return NULL;
+}
+
+bool chip_mode_pin_matches(const ChipModePin* pin, uint8_t kind, uint8_t alt, bool i2c_high) {
+    return pin && pin->kind == kind && pin->alt == alt && pin->i2c_high == i2c_high;
+}
+
+size_t chip_mode_pin_count(void) {
+    return CHIP_MODE_PIN_COUNT;
+}
+
+const ChipModePin* chip_mode_pin_get(size_t index) {
+    if(index >= CHIP_MODE_PIN_COUNT) return NULL;
+    return &chip_mode_pins[index];
 }

--- a/non_catalog_apps/fake_chip_detector/chip_db.h
+++ b/non_catalog_apps/fake_chip_detector/chip_db.h
@@ -17,7 +17,22 @@ typedef struct {
 
 typedef struct {
     const char* name;
-    const char* kind; // what the part does, in plain words
+    // What the part does, in plain words. Two constraints, because the one
+    // string is used two ways.
+    //
+    // It has to survive being dropped into a sentence: the report writes "That
+    // part is %s." around it. "Press/temp/humidity" came out as "That part is a
+    // press/temp/humidity." -- a sentence that stops halfway. Give it a head
+    // noun, even when the label would read fine without one.
+    //
+    // And it has to fit the narrowest screen that draws it, which is NOT YOURS:
+    // article and kind together start at x=28, so 100px of the 128 are left.
+    // The longest one here is "a magnetic angle sensor" at 98px. Counting
+    // characters does not predict this -- "Temp/humidity sensor" is 20 of them
+    // and overflows by a pixel, "Magnetic angle sensor" is 21 and fits -- so a
+    // long new kind wants measuring against FontSecondary, not estimating:
+    // tools/screen_width.py does it exactly, off the device.
+    const char* kind;
     uint8_t addrs[CHIP_MAX_ADDRS]; // 0xFF = end of list
     uint8_t range_lo; // inclusive contiguous address range, 0 = unused
     uint8_t range_hi;
@@ -27,12 +42,27 @@ typedef struct {
 } ChipEntry;
 
 typedef enum {
+    // Nothing has been decided yet, and it is first so that zero means this.
+    // GENUINE used to be the zero value, which made "this chip is real" the
+    // answer any uninitialised or partly filled ChipIdentification gave --
+    // including the one chip_db_identify memsets before it starts work. Every
+    // path through that function does assign a verdict today, so nothing shows
+    // it; the point is that the app's worst possible output should never be one
+    // missing return statement away.
+    VerdictNotChecked,
     VerdictGenuine, // all ID registers match
     VerdictWrongChip, // some IDs of a known chip match and others do not
     VerdictNoMatch, // answers, but nothing matched any candidate here
     VerdictDetectedNoId, // address belongs to a chip without an ID register
     VerdictUnknown, // address not in the database
     VerdictNoAnswer, // device stopped answering register reads
+    // Several parts fit what was read and nothing on the bus separates them:
+    // two chips with no ID register sharing an address, or two whose ID checks
+    // both passed with equal weight. New values go at the end -- every switch
+    // over this enum has a default:, so the compiler will not point at the ones
+    // that need a case, and a value inserted in the middle would silently
+    // renumber the rest.
+    VerdictAmbiguous,
 } ChipVerdict;
 
 typedef struct {
@@ -51,6 +81,12 @@ typedef struct {
     ChipVerdict verdict;
     IdReadResult reads[CHIP_MAX_CHECKS];
     uint8_t read_count;
+    // How many parts fit, for VerdictAmbiguous and nothing else. Counted where
+    // the decision is made rather than recovered afterwards, because the two
+    // ways a result can be ambiguous -- several parts with no ID register, or
+    // several whose ID checks passed equally -- would need counting differently
+    // and the verdict does not record which one happened.
+    uint8_t candidates;
 } ChipIdentification;
 
 // Probes the device at addr7 and fills out the identification result.
@@ -68,6 +104,61 @@ void chip_verdict_explain(ChipVerdict verdict, const char** line1, const char** 
 
 // True when the verdict means "nothing is wrong here".
 bool chip_verdict_is_good(ChipVerdict verdict);
+
+// A pin that can take a part off the I2C bus entirely while leaving it in
+// perfect health. Two flavours: a protocol select that hands the part to SPI
+// or UART, and an enable pin that holds it in reset. Either way an I2C sweep
+// finds nothing, which is indistinguishable from a dead chip unless the app
+// says otherwise -- and someone has already returned a working BNO055 over
+// exactly this.
+typedef enum {
+    ModePinProtocol, // picks which bus the part speaks
+    ModePinEnable, // holds the part in reset or shutdown
+} ModePinKind;
+
+typedef enum {
+    ModeAltSpi,
+    ModeAltUart,
+    ModeAltOff, // not another protocol: the part simply is not running
+} ModeAlt;
+
+typedef struct {
+    const char* chip; // exact ChipEntry.name; the doc generator checks this
+    const char* pad; // what the breakout silkscreens: "CSB", "CS", "PS1"
+    uint8_t kind; // ModePinKind
+    uint8_t alt; // ModeAlt: where the part goes when the pad is wrong
+    bool i2c_high; // level this pad needs for the part to speak I2C
+    // Sampled at reset. Strapping the pad is then not enough on its own: the
+    // part keeps whatever it latched until the power is cycled, which is why
+    // the fix screen offers to cycle the rail rather than just say "rescan".
+    bool latched;
+} ChipModePin;
+
+// NULL is the normal answer: most parts have no such pin.
+const ChipModePin* chip_mode_pin_for(const char* chip_name);
+
+// The silent-bus screens work the other way round: nothing identified itself,
+// so there is no chip name to look up -- only the label the user read off the
+// board. A silkscreen label names a class of pin, and this turns that class
+// back into the set of parts the tool can actually vouch for.
+//
+// i2c_high is part of the key rather than assumed from the kind. A future row
+// where a low level is the I2C one would otherwise be listed under prose
+// claiming the opposite of its own datasheet quote.
+bool chip_mode_pin_matches(const ChipModePin* pin, uint8_t kind, uint8_t alt, bool i2c_high);
+
+// Iteration, for the docs generator and the silent-bus screens.
+size_t chip_mode_pin_count(void);
+const ChipModePin* chip_mode_pin_get(size_t index);
+
+// The parts at this address that carry no ID register, newest-registered last.
+// Returns how many there are in total, which can exceed `max`; `out` may be
+// NULL to ask for the count alone.
+//
+// Two of them at one address is not an exotic case -- 0x68 has the DS3231 and
+// the DS1307, 0x40 has three -- and there is nothing on the bus that tells them
+// apart. The screens use this to say how many rather than to pick one.
+size_t chip_db_no_id_at(uint8_t addr7, const ChipEntry** out, size_t max);
 
 // Number of chips in the database, for the About screen.
 size_t chip_db_count(void);

--- a/non_catalog_apps/fake_chip_detector/fake_chip_detector.c
+++ b/non_catalog_apps/fake_chip_detector/fake_chip_detector.c
@@ -721,10 +721,27 @@ static void scan_draw_callback(Canvas* canvas, void* model) {
             canvas_set_font(canvas, FontSecondary);
             if(kind) canvas_draw_str(canvas, 26, 25, kind);
 
+            // The note belongs on this screen and not only on the detail
+            // screen behind it. This is the screen that asks whether the part
+            // is what was bought, and a GY-271 board reading QMC5883P is
+            // exactly the case where the user cannot answer that from what is
+            // drawn: the number silkscreened on the module and the number
+            // burned into the die are different things, and nothing else here
+            // says so. Every note in the database fits centred on 128px --
+            // tools/screen_width.py measures them, the widest clears by four
+            // -- so none needs truncating; they do need the room, which is why
+            // the two lines below drop by five when a note is present.
+            const char* note = dev->ident.chip ? dev->ident.chip->note : NULL;
+            uint8_t vy = 38, qy = 49;
+            if(note) {
+                canvas_draw_str_aligned(canvas, 64, 34, AlignCenter, AlignBottom, note);
+                vy = 43;
+                qy = 52;
+            }
             snprintf(buf, sizeof(buf), "%s at 0x%02X", chip_verdict_headline(v), dev->addr);
-            canvas_draw_str_aligned(canvas, 64, 38, AlignCenter, AlignBottom, buf);
+            canvas_draw_str_aligned(canvas, 64, vy, AlignCenter, AlignBottom, buf);
             canvas_draw_str_aligned(
-                canvas, 64, 49, AlignCenter, AlignBottom, "Is this what you bought?");
+                canvas, 64, qy, AlignCenter, AlignBottom, "Is this what you bought?");
             draw_choice_bar(canvas);
             return;
         }

--- a/non_catalog_apps/fake_chip_detector/fake_chip_detector.c
+++ b/non_catalog_apps/fake_chip_detector/fake_chip_detector.c
@@ -41,8 +41,10 @@ typedef enum {
     FakeChipViewReport,
     FakeChipViewSaved,
     FakeChipViewOneWire,
+    FakeChipViewSilent,
     FakeChipViewTests,
     FakeChipViewTestHelp,
+    FakeChipViewSelftest,
     FakeChipViewAbout,
 } FakeChipViewId;
 
@@ -51,6 +53,7 @@ typedef enum {
     MenuIndexScan,
     MenuIndexOneWire,
     MenuIndexTests,
+    MenuIndexSelftest,
     MenuIndexSettings,
     MenuIndexChips,
     MenuIndexSaved,
@@ -77,6 +80,12 @@ typedef struct {
     uint8_t selected;
     uint8_t scroll;
     I2CBusCheck bus; // captured before the sweep, drives the failure hints
+    // The sweep is over and the serial line is being heard out. Its own flag
+    // rather than a stage of `scanning`, because the progress bar is finished
+    // and full by then and the screen has a different thing to say.
+    bool listening;
+    uint8_t listen_outcome; // UartListenOutcome, once the listen has ended
+    UartListenResult listen;
     char status_msg[20];
     char saved_name[32]; // filename of the last report, shown after saving
     // Knowing which chip it is only answers half the question. The other half
@@ -116,6 +125,12 @@ typedef struct {
     uint8_t selected;
     bool busy;
     bool explain; // the "what this proves" panel is showing
+
+    // Two fields rather than one, because a write that failed has to be as
+    // loud as one that worked. A user who walks away believing a file exists
+    // is worse off than one who was told plainly that it does not.
+    char saved_name[SAVED_NAME_LEN]; // filename of the last report, on success
+    bool save_failed; // the SD write did not go through
 } OneWireViewModel;
 
 typedef struct {
@@ -138,6 +153,39 @@ typedef struct {
     char message[LIVE_TEST_LINE_LEN];
 } TestsViewModel;
 
+// Things the worker thread needs the dispatcher thread to do. The worker may
+// touch view models under their own lock, but navigation belongs to the thread
+// that owns the event loop.
+typedef enum {
+    AppEventFixDone = 1,
+} AppCustomEvent;
+
+typedef struct {
+    uint8_t selected; // which family of pad labels the user says they are on
+    uint8_t level; // I2CPadLevel, as last settled by the meter
+    uint32_t frame;
+    uint8_t stage; // I2CFixStage; I2CFixIdle means the meter owns the screen
+    // A pin that is only read at reset can be strapped with the one spare wire
+    // and let go afterwards. One that has to be held cannot, and the screen
+    // says that instead of pretending.
+    bool needs_fifth_wire;
+    // Frame the report was written on, or 0. A save nobody is told about is
+    // the same as no save: the footer says so for a few seconds and then goes
+    // back to explaining the pad.
+    uint32_t saved_frame;
+} SilentViewModel;
+
+// The transport can be proved with one jumper and no sensor at all, and until
+// this screen existed there was no way to ask for that from the device -- the
+// only thing that ever called it was a plan. Somebody whose sensor is silent
+// deserves to know whether the app's own serial path works before they conclude
+// anything about the part in their hand.
+typedef struct {
+    uint8_t state; // I2CSelftestState
+    bool running;
+    char detail[I2C_SELFTEST_DETAIL_SIZE];
+} SelftestViewModel;
+
 typedef struct {
     Gui* gui;
     ViewDispatcher* view_dispatcher;
@@ -150,8 +198,10 @@ typedef struct {
     View* chips_view;
     View* saved_view;
     View* onewire_view;
+    View* silent_view;
     View* tests_view;
     View* test_help_view;
+    View* selftest_view;
     TextBox* report_box;
     FuriString* report_text;
     VariableItemList* settings_list;
@@ -378,6 +428,13 @@ static void app_start_scan(FakeChipApp* app) {
             m->selected = 0;
             m->scroll = 0;
             m->bus = (I2CBusCheck){0};
+            // Same reason as the answer below: what the last scan heard is not
+            // evidence about this module. Clearing it here rather than trusting
+            // the worker to overwrite it means a scan that is aborted before
+            // the listen leaves nothing behind either.
+            m->listening = false;
+            m->listen_outcome = UartListenUnavailable;
+            m->listen = (UartListenResult){0};
             m->status_msg[0] = '\0';
             // The question belongs to the module that was on the bus when it
             // was asked. Carrying the answer into the next scan silently skips
@@ -452,7 +509,9 @@ static void draw_verdict_icon(Canvas* canvas, uint8_t cx, uint8_t cy, ChipVerdic
         break;
     case VerdictNoMatch:
     case VerdictUnknown:
-        // Question mark in a ring
+    case VerdictAmbiguous:
+        // Question mark in a ring. Ambiguous belongs here and not with the
+        // silent ring: the bus answered, the identity is what is unresolved.
         canvas_draw_circle(canvas, cx, cy, 7);
         canvas_draw_line(canvas, cx - 2, cy - 3, cx + 1, cy - 4);
         canvas_draw_line(canvas, cx + 1, cy - 4, cx + 2, cy - 1);
@@ -535,7 +594,10 @@ static void scan_draw_callback(Canvas* canvas, void* model) {
     canvas_set_font(canvas, FontPrimary);
 
     if(m->scanning) {
-        canvas_draw_str(canvas, 2, 12, "Scanning bus...");
+        // Two seconds of an unmoving progress bar at 0x77 reads as a hang, and
+        // a user who thinks the app has hung stops trusting the answer it
+        // eventually gives. Say the thing instead.
+        canvas_draw_str(canvas, 2, 12, m->listening ? "Nothing on I2C." : "Scanning bus...");
         draw_scan_spinner(canvas, 112, 20, m->frame);
 
         uint8_t span = I2C_SCAN_ADDR_LAST - I2C_SCAN_ADDR_FIRST;
@@ -545,19 +607,29 @@ static void scan_draw_callback(Canvas* canvas, void* model) {
 
         canvas_set_font(canvas, FontSecondary);
         char buf[28];
-        snprintf(buf, sizeof(buf), "addr 0x%02X   found: %u", m->progress_addr, m->found_count);
-        canvas_draw_str(canvas, 4, 52, buf);
+        if(m->listening) {
+            canvas_draw_str(canvas, 4, 52, "Listening on pin 16...");
+        } else {
+            snprintf(
+                buf, sizeof(buf), "addr 0x%02X   found: %u", m->progress_addr, m->found_count);
+            canvas_draw_str(canvas, 4, 52, buf);
+        }
         return;
     }
 
     if(m->found_count == 0) {
-        canvas_draw_str_aligned(canvas, 64, 11, AlignCenter, AlignBottom, "No devices found");
+        // "No devices found" is a verdict about the world. "No I2C answer" is
+        // a statement about what happened, and the difference is not cosmetic:
+        // someone read the old headline as a conclusion, pressed nothing else,
+        // and handed a working sensor back to a courier.
+        canvas_draw_str_aligned(canvas, 64, 11, AlignCenter, AlignBottom, "No I2C answer");
         canvas_set_font(canvas, FontSecondary);
 
         // Hints keyed to what the electrical check actually saw
         const char* l1;
         const char* l2;
         const char* l3;
+        char heard[26];
         switch(m->bus.health) {
         case I2CBusStuckLow:
             l1 = m->bus.scl_stuck ?
@@ -574,15 +646,53 @@ static void scan_draw_callback(Canvas* canvas, void* model) {
             l3 = "Check pins 8, 9, 15, 16.";
             break;
         default:
-            l1 = "Bus is electrically OK.";
-            l2 = "Wrong address, SDA/SCL";
-            l3 = "swapped, or dead chip.";
+            // The sweep covers 0x08-0x77, so a wrong address is not one of the
+            // possibilities. A mode pin is: a part strapped to SPI or UART is
+            // powered, its pull-ups still hold the bus high, and it will never
+            // answer an address because in that state it does not have one.
+            l1 = "Board has power and its";
+            l2 = "pull-ups are there. Some";
+            l3 = "chips boot with I2C off.";
+
+            // Unless the listen actually heard the thing. Then this stops
+            // being a list of possibilities and becomes a measurement, and it
+            // is the strongest one this app can make without an ID register:
+            // the part is powered, running, and talking on a bus that is not
+            // I2C. Nobody should hand that back to a courier.
+            if(m->listen_outcome == UartListenHeard) {
+                if(m->listen.bytes) {
+                    snprintf(
+                        heard,
+                        sizeof(heard),
+                        "pin 16, at %lu baud.",
+                        (unsigned long)m->listen.baud);
+                    l1 = "Something IS talking on";
+                    l2 = heard;
+                    l3 = "That is a serial line.";
+                } else {
+                    // Framing errors and no clean bytes: the line is moving,
+                    // but not at any rate that was tried. Claiming a rate here
+                    // would be reporting the guess instead of the measurement.
+                    l1 = "Pin 16 is switching, but";
+                    l2 = "at no rate this tried.";
+                    l3 = "Something is alive.";
+                }
+            }
             break;
         }
         canvas_draw_str_aligned(canvas, 64, 26, AlignCenter, AlignBottom, l1);
         canvas_draw_str_aligned(canvas, 64, 36, AlignCenter, AlignBottom, l2);
         canvas_draw_str_aligned(canvas, 64, 46, AlignCenter, AlignBottom, l3);
-        canvas_draw_str_aligned(canvas, 64, 62, AlignCenter, AlignBottom, "OK = rescan");
+
+        // The offer, not a full stop. The third line used to be the last item
+        // in a list of bad possibilities with nothing attached to it.
+        canvas_draw_box(canvas, 0, 55, 128, 9);
+        canvas_set_color(canvas, ColorWhite);
+        canvas_draw_str(canvas, 4, 62, "OK");
+        canvas_draw_str(canvas, 20, 62, "rescan");
+        canvas_draw_str_aligned(canvas, 124, 62, AlignRight, AlignBottom, "find out");
+        draw_right_key(canvas, 124 - canvas_string_width(canvas, "find out") - 9, 61);
+        canvas_set_color(canvas, ColorBlack);
         return;
     }
 
@@ -593,7 +703,13 @@ static void scan_draw_callback(Canvas* canvas, void* model) {
     if(m->found_count == 1) {
         const I2CFoundDevice* dev = &m->found[0];
         ChipVerdict v = dev->ident.verdict;
-        const char* name = dev->ident.chip ? dev->ident.chip->name : "Unknown chip";
+        // No chip means one of two different things, and they read nothing
+        // alike. Nothing here answered to anything known, or several known
+        // parts answered equally well -- the second is a populated address
+        // this tool declines to guess at, not an unrecognised one.
+        const char* name = dev->ident.chip       ? dev->ident.chip->name :
+                           v == VerdictAmbiguous ? "Several parts" :
+                                                   "Unknown chip";
         const char* kind = dev->ident.chip ? dev->ident.chip->kind : NULL;
 
         if(m->answer == AnswerAsking) {
@@ -645,7 +761,22 @@ static void scan_draw_callback(Canvas* canvas, void* model) {
             canvas_draw_str(canvas, 36, 20, proven ? "ALL GOOD" : "IT ANSWERS");
             canvas_set_font(canvas, FontSecondary);
             canvas_draw_str(canvas, 36, 30, proven ? "Real deal." : "No ID to check.");
-            canvas_draw_str_aligned(canvas, 64, 42, AlignCenter, AlignBottom, name);
+            if(v == VerdictAmbiguous) {
+                // The count, not the names: at 0x40 there are three of them and
+                // the shortest honest list of the three is wider than the
+                // screen. The detail screen and the report have the room to
+                // name them, and this line says there is something to go and
+                // read there.
+                snprintf(
+                    buf,
+                    sizeof(buf),
+                    "%u parts share 0x%02X",
+                    (unsigned)dev->ident.candidates,
+                    dev->addr);
+                canvas_draw_str_aligned(canvas, 64, 42, AlignCenter, AlignBottom, buf);
+            } else {
+                canvas_draw_str_aligned(canvas, 64, 42, AlignCenter, AlignBottom, name);
+            }
 
             // The ID said what it is; a live test says it works. Offered here
             // and only here, because this is the moment the answer is yes.
@@ -664,7 +795,12 @@ static void scan_draw_callback(Canvas* canvas, void* model) {
             canvas_draw_str(canvas, 28, 16, "NOT YOURS");
             canvas_set_font(canvas, FontSecondary);
             canvas_draw_str(canvas, 28, 26, "You were sold");
-            snprintf(buf, sizeof(buf), "a %s", kind ? kind : name);
+            // kind is NULL only when nothing in the database matched -- every
+            // row has one, and the generator that builds SUPPORTED_CHIPS.md
+            // fails the build if a row does not. So `name` here is the
+            // "Unknown chip" placeholder rather than a part number: prose, and
+            // it lowercases like prose.
+            report_phrase_kind(buf, sizeof(buf), kind ? kind : name);
             canvas_draw_str(canvas, 28, 35, buf);
             canvas_draw_str_aligned(
                 canvas, 64, 48, AlignCenter, AlignBottom, "Save proof for the seller.");
@@ -709,23 +845,22 @@ static void scan_draw_callback(Canvas* canvas, void* model) {
     draw_action_bar(canvas, "OK: details", true);
 }
 
-/* Writes a snapshot of the scan results to /ext/apps_data/fake_chip_detector/.
- * Takes a copy rather than the live model: SD writes can stall for seconds
- * and must never run while the view-model mutex is held. */
-static bool scan_save_log(
-    const I2CFoundDevice* found,
-    uint8_t count,
-    bool disputed,
+/* Files an already-built report in /ext/apps_data/fake_chip_detector/ and
+ * hands back the name it chose. The document and the name it is filed under
+ * are made from the same DateTime, so a report cannot be dated one minute in
+ * its own text and another in the folder. Two kinds of report go through here
+ * — the I2C scan and the 1-Wire bus — and only the writing is shared: the
+ * documents themselves say different things and are built apart. */
+static bool report_save_text(
+    const FuriString* text,
+    const DateTime* dt,
     char* out_name,
     size_t out_name_size) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
     bool ok = false;
 
-    DateTime dt;
-    furi_hal_rtc_get_datetime(&dt);
-
     char name[SAVED_NAME_LEN];
-    report_filename_make(name, sizeof(name), &dt);
+    report_filename_make(name, sizeof(name), dt);
     if(out_name) snprintf(out_name, out_name_size, "%s", name);
 
     FuriString* path = furi_string_alloc_printf(APP_DATA_PATH("%s"), name);
@@ -733,16 +868,33 @@ static bool scan_save_log(
 
     File* file = storage_file_alloc(storage);
     if(storage_file_open(file, furi_string_get_cstr(path), FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
-        FuriString* text = furi_string_alloc();
-        report_build(text, found, count, disputed, &dt);
         size_t len = furi_string_size(text);
         ok = storage_file_write(file, furi_string_get_cstr(text), len) == len;
-        furi_string_free(text);
     }
     storage_file_close(file);
     storage_file_free(file);
     furi_string_free(path);
     furi_record_close(RECORD_STORAGE);
+    return ok;
+}
+
+/* Writes a snapshot of the scan results. Takes a copy rather than the live
+ * model: SD writes can stall for seconds and must never run while the
+ * view-model mutex is held. */
+static bool scan_save_log(
+    const I2CFoundDevice* found,
+    uint8_t count,
+    bool disputed,
+    const SilentDiagnosis* silent,
+    char* out_name,
+    size_t out_name_size) {
+    DateTime dt;
+    furi_hal_rtc_get_datetime(&dt);
+
+    FuriString* text = furi_string_alloc();
+    report_build(text, found, count, disputed, &dt, silent);
+    bool ok = report_save_text(text, &dt, out_name, out_name_size);
+    furi_string_free(text);
     return ok;
 }
 
@@ -755,7 +907,7 @@ static void app_start_live_test(
 
 // Snapshots the results and writes the report outside the model lock: SD
 // writes can stall for seconds and must never hold up the GUI.
-static void app_save_log(FakeChipApp* app, bool disputed) {
+static void app_save_log(FakeChipApp* app, bool disputed, const SilentDiagnosis* silent) {
     I2CFoundDevice* snapshot = malloc(sizeof(I2CFoundDevice) * I2C_SCAN_MAX_FOUND);
     uint8_t count = 0;
     with_view_model(
@@ -769,7 +921,7 @@ static void app_save_log(FakeChipApp* app, bool disputed) {
         false);
 
     char name[32] = {0};
-    bool saved = scan_save_log(snapshot, count, disputed, name, sizeof(name));
+    bool saved = scan_save_log(snapshot, count, disputed, silent, name, sizeof(name));
     free(snapshot);
 
     with_view_model(
@@ -797,6 +949,10 @@ static I2CNotifyKind verdict_notify_kind(ChipVerdict verdict) {
         return I2CNotifyBad;
     case VerdictUnknown:
         return I2CNotifyAttention;
+    // Neutral, like DetectedNoId, because it lands on the same screen and for
+    // the same reason: something real answered and this tool cannot name it.
+    case VerdictAmbiguous:
+        return I2CNotifyNeutral;
     default:
         return I2CNotifyNeutral;
     }
@@ -813,6 +969,7 @@ static bool scan_input_callback(InputEvent* event, void* context) {
     bool answered_wrong = false;
     bool disputed = false;
     bool show_report = false;
+    bool open_silent = false;
     const LiveTest* start_live = NULL;
     uint8_t live_addr = 0;
 
@@ -876,6 +1033,11 @@ static bool scan_input_callback(InputEvent* event, void* context) {
                         m->scroll = m->selected - SCAN_LIST_ROWS + 1;
                     consumed = true;
                 } else if(
+                    event->key == InputKeyRight && m->found_count == 0 &&
+                    event->type == InputTypeShort) {
+                    open_silent = true; // the only screen that can still help
+                    consumed = true;
+                } else if(
                     event->key == InputKeyRight && m->found_count > 0 &&
                     event->type == InputTypeShort) {
                     if(m->found_count == 1 && m->answer != AnswerAsking) {
@@ -897,11 +1059,13 @@ static bool scan_input_callback(InputEvent* event, void* context) {
     if(show_report) app_show_report(app, disputed);
 
     if(do_save) {
-        app_save_log(app, disputed);
+        app_save_log(app, disputed, NULL);
         i2c_notify_play(app->notifications, I2CNotifyNeutral);
     }
 
     if(rescan) app_start_scan(app);
+
+    if(open_silent) app_switch_view(app, FakeChipViewSilent);
 
     if(open_detail) {
         I2CFoundDevice selected_dev;
@@ -926,6 +1090,424 @@ static bool scan_input_callback(InputEvent* event, void* context) {
     return consumed;
 }
 
+/* ---------------- Silent bus ---------------- */
+
+// Where someone goes after a scan finds nothing and the wiring is fine. The
+// question it answers is not "what chip is this" but "is it broken", and the
+// two have different evidence: a part strapped to SPI or UART is healthy,
+// powered and completely unable to answer an I2C address.
+//
+// It asks about the pad rather than the chip on purpose. The user arrived here
+// because nothing identified itself, so a list of chip names invites a
+// confident explanation of the wrong part - and the pad's label is printed on
+// the board in their hand.
+#define SILENT_ROWS 4
+
+typedef struct {
+    const char* labels; // what the board might silkscreen for this kind of pin
+    const char* when_high;
+    const char* when_low;
+    bool explains_high; // this level is a reason the part cannot answer
+    bool explains_low;
+    bool want_high; // level this kind of pad needs for the part to speak I2C
+    // Sampled once at reset and then kept. That is what makes a fix possible on
+    // four wires: the pad only has to be held while the part restarts, so the
+    // same wire can go back to carrying SDA afterwards. A pin that has to be
+    // held the whole time cannot be fixed and helped at once with four wires,
+    // and saying so is the honest answer.
+    bool latched;
+    // Which class of pin in chip_mode_pins these labels stand for, so the
+    // screen can name the parts that have one. The user picked a silkscreen
+    // label, not a chip, and (kind, alt, want_high) is what turns that label
+    // back into a set of parts -- matching on the label strings themselves
+    // would tie the database to the wording of a menu row.
+    bool has_mode_class; // false for the address row: those pads pick no bus
+    uint8_t kind; // ModePinKind
+    uint8_t alt; // ModeAlt
+} PadFamily;
+
+// Named fields, not positions. Five of these are booleans in a row and one of
+// them decides which way somebody is told to strap a pin: a transposition here
+// would be invisible on the page and wrong on the bench.
+static const PadFamily pad_families[SILENT_ROWS] = {
+    // The SPI class: BME280, BMP280, most ST and ADI accelerometers. Every one
+    // of them wants this pad high to stay on I2C. The Bosch parts latch it:
+    // "the I2C interface is disabled until the next power-on-reset".
+    {
+        .labels = "CS  CSB  NSS",
+        .when_high = "High = I2C. Not this.",
+        .when_low = "Low picks SPI. This is it.",
+        .explains_low = true,
+        .want_high = true,
+        .latched = true,
+        .has_mode_class = true,
+        .kind = ModePinProtocol,
+        .alt = ModeAltSpi,
+    },
+    // Protocol select proper, which is the BNO055 case. Table 4-4: the pins are
+    // read at reset and must not be left floating.
+    {
+        .labels = "PS0  PS1  SEL",
+        .when_high = "High picks UART or SPI.",
+        .when_low = "Low picks I2C. Not this.",
+        .explains_high = true,
+        .latched = true,
+        .has_mode_class = true,
+        .kind = ModePinProtocol,
+        .alt = ModeAltUart,
+    },
+    // Not a protocol at all: the part is simply held off, and it stays off for
+    // exactly as long as the pin is low. Nothing is latched, so there is no
+    // moment where letting go is safe.
+    {
+        .labels = "XSHUT  RES  EN  RST",
+        .when_high = "High = enabled. Not this.",
+        .when_low = "Low holds it in reset.",
+        .explains_low = true,
+        .want_high = true,
+        .has_mode_class = true,
+        .kind = ModePinEnable,
+        .alt = ModeAltOff,
+    },
+    // Ruling something out is progress and should read as progress. No mode
+    // class on purpose: an address pin picks no bus, so kind and alt are left
+    // at zero and never read.
+    {
+        .labels = "AD0  ADR  SDO",
+        .when_high = "Address only - all swept.",
+        .when_low = "Address only - all swept.",
+    },
+};
+
+// ~3 seconds at the 60ms tick. A save nobody is told about is the same as no
+// save, and every screen here can write one.
+static bool silent_saved_recently(const SilentViewModel* m) {
+    return m->saved_frame && m->frame - m->saved_frame < 50;
+}
+
+// Is this level, on this kind of pad, a reason the part cannot answer?
+static bool silent_pad_explains(const PadFamily* fam, uint8_t level) {
+    if(level == I2CPadUnknown) return false; // nothing measured yet, nothing to conclude
+    if(!fam->explains_high && !fam->explains_low) return false; // the address row
+    // A mode pin left floating is not a grey area: BST-BNO055-DS000 says
+    // outright that the protocol select pins may not be left floating, and
+    // Bosch's pressure parts want CSB tied rather than left to drift. Whatever
+    // such a pad settles on at power-up is luck, and luck is a reason to hold
+    // it properly and try again.
+    if(level == I2CPadFloating) return true;
+    return (level == I2CPadHigh && fam->explains_high) ||
+           (level == I2CPadLow && fam->explains_low);
+}
+
+// "Known: BMP280 BME280 +4". A rule with no example behind it is something to
+// be taken on trust; a part number is something the reader can compare with
+// the board in their hand. Empty when this build has no verified rows for the
+// class, and empty is the right answer then -- a heading over nothing would
+// read as "this tool knows of none", which is a different claim.
+static void silent_known_parts(Canvas* canvas, const PadFamily* fam, char* out, size_t size) {
+    out[0] = '\0';
+    if(!fam->has_mode_class) return;
+
+    // Measured against the font rather than counted in characters: these are
+    // part numbers, all capitals and digits, and they run far wider per
+    // character than the prose this footer normally carries. Room is kept for
+    // the tail, because a list that quietly ran out of room reads as the whole
+    // set -- and the whole set is what somebody would check their board
+    // against.
+    uint16_t budget = 126 - canvas_string_width(canvas, " +99");
+    size_t used = 0;
+    uint8_t hidden = 0;
+    for(size_t i = 0; i < chip_mode_pin_count(); i++) {
+        const ChipModePin* p = chip_mode_pin_get(i);
+        if(!chip_mode_pin_matches(p, fam->kind, fam->alt, fam->want_high)) continue;
+        if(!hidden) {
+            snprintf(out + used, size - used, "%s%s", used ? " " : "Known: ", p->chip);
+            if(canvas_string_width(canvas, out) <= budget) {
+                used = strlen(out);
+                continue;
+            }
+            out[used] = '\0'; // it did not fit; put the string back as it was
+        }
+        // Once one name has been dropped every later one is too, even where a
+        // shorter one would have fitted. Skipping ahead to whatever fits would
+        // print a list in an order that matches nothing.
+        hidden++;
+    }
+    // used == 0 means even the first name was too wide, and then there is no
+    // list for "+N" to be counting from.
+    if(hidden && used) snprintf(out + used, size - used, " +%u", (unsigned)hidden);
+}
+
+// One instruction, one thing the app is waiting to see. Every stage but the
+// first is left by a measurement, so the person can put the Flipper down and
+// use both hands: nothing here needs a keypress to move on.
+static void silent_draw_fix(Canvas* canvas, SilentViewModel* m) {
+    const PadFamily* fam = &pad_families[m->selected];
+    const char* title;
+    const char* l1;
+    const char* l2;
+    const char* foot = NULL;
+    bool spinner = true;
+
+    switch(m->stage) {
+    case I2CFixStrapping:
+        title = fam->want_high ? "Holding the pad high" : "Holding the pad low";
+        l1 = "Checking whether it";
+        l2 = "moves.";
+        break;
+    case I2CFixPadHeld:
+        // Not a failure to report apologetically: it is the answer. Somebody
+        // chose this in copper and the buyer could not have known.
+        title = "The board holds it";
+        l1 = fam->want_high ? "This pad is tied low on" : "This pad is tied high on";
+        l2 = "the board, not by you.";
+        foot = "Left: save the report";
+        spinner = false;
+        break;
+    case I2CFixWantPowerOff:
+        title = "Pull the power wire";
+        l1 = "Out of the sensor. Mode";
+        l2 = "pins are read at startup.";
+        foot = "Still powered.";
+        break;
+    case I2CFixWantPowerOn:
+        title = "Power is off";
+        l1 = "Plug it back in. The pad";
+        l2 = "is held for you.";
+        foot = "Waiting.";
+        break;
+    default: // I2CFixWantWire, and I2CFixDone for the frame before the rescan
+        title = "Put the wire back";
+        l1 = "On the sensor's SDA pad,";
+        l2 = "Flipper end in pin 15.";
+        foot = "Waiting for the bus.";
+        break;
+    }
+
+    if(silent_saved_recently(m)) foot = "Saved to the SD card.";
+
+    canvas_draw_str_aligned(canvas, 64, 12, AlignCenter, AlignBottom, title);
+    canvas_set_font(canvas, FontSecondary);
+    canvas_draw_str_aligned(canvas, 64, 27, AlignCenter, AlignBottom, l1);
+    canvas_draw_str_aligned(canvas, 64, 37, AlignCenter, AlignBottom, l2);
+    if(spinner) draw_scan_spinner(canvas, 64, 48, m->frame);
+    if(foot) {
+        canvas_draw_box(canvas, 0, 55, 128, 9);
+        canvas_set_color(canvas, ColorWhite);
+        canvas_draw_str_aligned(canvas, 64, 62, AlignCenter, AlignBottom, foot);
+        canvas_set_color(canvas, ColorBlack);
+    }
+}
+
+static void silent_draw_callback(Canvas* canvas, void* model) {
+    SilentViewModel* m = model;
+    canvas_clear(canvas);
+    canvas_set_font(canvas, FontPrimary);
+
+    if(m->needs_fifth_wire) {
+        // The one case four wires cannot solve, said plainly rather than
+        // offered as a fix that quietly does nothing.
+        canvas_draw_str_aligned(canvas, 64, 12, AlignCenter, AlignBottom, "Needs a fifth wire");
+        canvas_set_font(canvas, FontSecondary);
+        canvas_draw_str_aligned(
+            canvas, 64, 27, AlignCenter, AlignBottom, "This pin has to stay high");
+        canvas_draw_str_aligned(canvas, 64, 37, AlignCenter, AlignBottom, "the whole time, so it");
+        canvas_draw_str_aligned(
+            canvas, 64, 47, AlignCenter, AlignBottom, "cannot also carry SDA.");
+        canvas_draw_box(canvas, 0, 55, 128, 9);
+        canvas_set_color(canvas, ColorWhite);
+        canvas_draw_str_aligned(
+            canvas,
+            64,
+            62,
+            AlignCenter,
+            AlignBottom,
+            silent_saved_recently(m) ? "Saved to the SD card." : "Left: save the report");
+        canvas_set_color(canvas, ColorBlack);
+        return;
+    }
+
+    if(m->stage != I2CFixIdle) {
+        silent_draw_fix(canvas, m);
+        return;
+    }
+
+    const PadFamily* fam = &pad_families[m->selected];
+    bool explained = silent_pad_explains(fam, m->level);
+
+    // The meter needs four agreeing reads before it will say anything, and
+    // until then it says exactly that. Defaulting the headline to FLOATING
+    // would have announced a level nothing had measured -- and FLOATING is the
+    // one level that offers the fix on every mode family, so it would have
+    // offered to act on it too.
+    const char* title = "Reading the pad...";
+    if(m->level == I2CPadFloating) title = "Pad reads FLOATING";
+    if(m->level == I2CPadHigh) title = "Pad reads HIGH";
+    if(m->level == I2CPadLow) title = "Pad reads LOW";
+    canvas_draw_str_aligned(canvas, 2, 10, AlignLeft, AlignBottom, title);
+
+    canvas_set_font(canvas, FontSecondary);
+    // The fix is offered only once the reading and the chosen pad actually
+    // form a cause; before that there is nothing to fix and saying so would be
+    // a guess. Left saves either way -- Down belongs to the list, and the hint
+    // yields to the stronger action rather than the key going away.
+    canvas_draw_str_aligned(
+        canvas, 126, 10, AlignRight, AlignBottom, explained ? "OK fix" : "< save");
+    for(uint8_t row = 0; row < SILENT_ROWS; row++) {
+        uint8_t y = 22 + row * 10;
+        bool sel = (row == m->selected);
+        if(sel) {
+            canvas_draw_box(canvas, 0, y - 8, 128, 10);
+            canvas_set_color(canvas, ColorWhite);
+        }
+        canvas_draw_str(canvas, 4, y, pad_families[row].labels);
+        if(sel) canvas_set_color(canvas, ColorBlack);
+    }
+
+    // The footer is the whole point: it turns a bare level into a reason, and
+    // it changes as the cursor moves so nobody has to hold a lookup table in
+    // their head at a counter.
+    canvas_draw_box(canvas, 0, 55, 128, 9);
+    canvas_set_color(canvas, ColorWhite);
+    // Wide enough that the pixel budget always runs out first: no glyph in
+    // this font is narrower than two pixels, so 126 pixels cannot hold 64
+    // characters, and a name can never be cut in half by the buffer.
+    char known[64];
+    const char* foot;
+    if(silent_saved_recently(m)) {
+        foot = "Saved to the SD card.";
+    } else if(m->level == I2CPadUnknown) {
+        // Falling through to the high/low line here would have printed what a
+        // LOW reading means, on a pad nothing had read yet.
+        foot = "Measuring...";
+    } else if(m->level == I2CPadFloating) {
+        // Alternating, because the likeliest cause is not the pad at all: the
+        // wire got moved at the Flipper end instead of the sensor end.
+        foot = (m->frame / 24) % 2 ? "Wire still in pin 15?" : "Nothing drives this pad.";
+    } else {
+        foot = m->level == I2CPadHigh ? fam->when_high : fam->when_low;
+        // The parts get a turn only once the reading and the pad agree that
+        // something is wrong. Naming the SPI-selecting parts under "High =
+        // I2C. Not this." would have the footer argue with itself.
+        //
+        // Alternating rather than replacing: the rule is the answer and has to
+        // come back round. Somebody holding a module that is on neither list
+        // still needs to be told what the level means.
+        if(explained && (m->frame / 24) % 2) {
+            silent_known_parts(canvas, fam, known, sizeof(known));
+            if(known[0]) foot = known;
+        }
+    }
+    canvas_draw_str_aligned(canvas, 64, 62, AlignCenter, AlignBottom, foot);
+    canvas_set_color(canvas, ColorBlack);
+}
+
+static void silent_enter_callback(void* context) {
+    FakeChipApp* app = context;
+    app->current_view = FakeChipViewSilent;
+    with_view_model(
+        app->silent_view,
+        SilentViewModel * m,
+        {
+            m->stage = I2CFixIdle;
+            m->needs_fifth_wire = false;
+            m->saved_frame = 0;
+            m->level = I2CPadUnknown; // the meter fills this in, ~200ms from now
+        },
+        true);
+    i2c_worker_pad_watch_start(app->worker);
+}
+
+static bool silent_input_callback(InputEvent* event, void* context) {
+    FakeChipApp* app = context;
+    if(event->type != InputTypeShort && event->type != InputTypeRepeat) return false;
+
+    bool consumed = false;
+    bool start_fix = false;
+    bool want_high = false;
+    bool back_to_meter = false;
+    bool do_save = false;
+    SilentDiagnosis diag = {0};
+    with_view_model(
+        app->silent_view,
+        SilentViewModel * m,
+        {
+            bool in_fix = m->stage != I2CFixIdle || m->needs_fifth_wire;
+            if(event->key == InputKeyLeft) {
+                // Saving is allowed from every one of these screens on purpose:
+                // "the board ties this pad low" is exactly the sentence someone
+                // needs in writing at a parcel counter.
+                diag.pad_measured = m->level != I2CPadUnknown;
+                diag.pad_level = m->level;
+                diag.pad_labels = pad_families[m->selected].labels;
+                diag.pad_held = m->stage == I2CFixPadHeld;
+                diag.pad_wanted_high = pad_families[m->selected].want_high;
+                diag.pad_mode_known = pad_families[m->selected].has_mode_class;
+                diag.pad_mode_kind = pad_families[m->selected].kind;
+                diag.pad_mode_alt = pad_families[m->selected].alt;
+                m->saved_frame = m->frame ? m->frame : 1;
+                do_save = true;
+                consumed = true;
+            } else if(event->key == InputKeyBack && in_fix) {
+                m->stage = I2CFixIdle;
+                m->needs_fifth_wire = false;
+                back_to_meter = true;
+                consumed = true;
+            } else if(in_fix) {
+                consumed = true; // the run advances on measurements, not keys
+            } else if(event->key == InputKeyUp && m->selected > 0) {
+                m->selected--;
+                consumed = true;
+            } else if(event->key == InputKeyDown && m->selected + 1 < SILENT_ROWS) {
+                m->selected++;
+                consumed = true;
+            } else if(event->key == InputKeyOk) {
+                const PadFamily* fam = &pad_families[m->selected];
+                bool explained = silent_pad_explains(fam, m->level);
+                if(explained && fam->latched) {
+                    m->stage = I2CFixStrapping;
+                    want_high = fam->want_high;
+                    start_fix = true;
+                    consumed = true;
+                } else if(explained) {
+                    m->needs_fifth_wire = true;
+                    consumed = true;
+                }
+            }
+        },
+        consumed);
+
+    // Outside the model lock, like every other input handler here: the fix run
+    // waits on a person's hands and an SD write can stall for seconds.
+    if(start_fix) i2c_worker_fix_start(app->worker, want_high);
+    if(back_to_meter) {
+        i2c_worker_fix_stop(app->worker);
+        i2c_worker_pad_watch_start(app->worker);
+    }
+
+    if(do_save) {
+        i2c_worker_get_bus(app->worker, &diag.bus);
+        // Straight from the worker rather than from the scan view model: this
+        // is the one measurement in the document that the app made on its own,
+        // without being asked, and it should not depend on a screen the user
+        // may never have looked at having been updated.
+        diag.listen_outcome = (uint8_t)i2c_worker_get_listen(app->worker, &diag.listen);
+        app_save_log(app, false, &diag);
+        i2c_notify_play(app->notifications, I2CNotifyNeutral);
+    }
+    return consumed;
+}
+
+static void silent_exit_callback(void* context) {
+    FakeChipApp* app = context;
+    // Guarded, never unconditional: the dispatcher runs this after the next
+    // view has already claimed the slot, so an unconditional assignment undoes
+    // the switch that is happening right now.
+    if(app->current_view == FakeChipViewSilent) app->current_view = FakeChipViewScan;
+    i2c_worker_pad_watch_stop(app->worker);
+    i2c_worker_fix_stop(app->worker); // releases the strap and the rail with it
+}
+
 static void worker_event_callback(I2CWorkerEvent event, void* context) {
     FakeChipApp* app = context;
 
@@ -935,6 +1517,9 @@ static void worker_event_callback(I2CWorkerEvent event, void* context) {
         bool any_genuine = false, any_bad = false;
         I2CBusCheck bus;
         i2c_worker_get_bus(app->worker, &bus);
+        bool listening = i2c_worker_is_listening(app->worker);
+        UartListenResult listen;
+        UartListenOutcome listen_outcome = i2c_worker_get_listen(app->worker, &listen);
 
         with_view_model(
             app->scan_view,
@@ -943,6 +1528,9 @@ static void worker_event_callback(I2CWorkerEvent event, void* context) {
                 m->progress_addr = i2c_worker_get_progress(app->worker);
                 m->found_count = i2c_worker_get_found(app->worker, m->found, I2C_SCAN_MAX_FOUND);
                 m->bus = bus;
+                m->listening = listening;
+                m->listen_outcome = (uint8_t)listen_outcome;
+                m->listen = listen;
                 if(done) {
                     m->scanning = false;
                     m->selected = 0;
@@ -970,7 +1558,7 @@ static void worker_event_callback(I2CWorkerEvent event, void* context) {
             }
             i2c_notify_play(app->notifications, kind);
 
-            if(app->settings.autosave && count > 0) app_save_log(app, false);
+            if(app->settings.autosave && count > 0) app_save_log(app, false, NULL);
         }
     } else if(event == I2CWorkerEventBusUpdate) {
         I2CBusCheck bus;
@@ -994,7 +1582,45 @@ static void worker_event_callback(I2CWorkerEvent event, void* context) {
         // Chirp once per transition, never on every poll
         if(became_connected) i2c_notify_play(app->notifications, I2CNotifyGenuine);
         if(became_wrong) i2c_notify_play(app->notifications, I2CNotifyAttention);
+    } else if(event == I2CWorkerEventSelftestDone) {
+        char detail[I2C_SELFTEST_DETAIL_SIZE];
+        I2CSelftestState state = i2c_worker_get_selftest(app->worker, detail, sizeof(detail));
+        with_view_model(
+            app->selftest_view,
+            SelftestViewModel * m,
+            {
+                m->state = (uint8_t)state;
+                m->running = false;
+                snprintf(m->detail, sizeof(m->detail), "%s", detail);
+            },
+            true);
+    } else if(event == I2CWorkerEventPadUpdate) {
+        uint8_t level = (uint8_t)i2c_worker_get_pad(app->worker);
+        with_view_model(app->silent_view, SilentViewModel * m, { m->level = level; }, true);
+    } else if(event == I2CWorkerEventFixUpdate) {
+        uint8_t stage = (uint8_t)i2c_worker_get_fix_stage(app->worker);
+        with_view_model(app->silent_view, SilentViewModel * m, { m->stage = stage; }, true);
+        // Hand the rest to the dispatcher thread. This callback runs on the
+        // worker, and switching views from here would drive the GUI from two
+        // threads at once; the custom-event queue is the seam that exists for
+        // exactly this.
+        if(stage == I2CFixDone) {
+            view_dispatcher_send_custom_event(app->view_dispatcher, AppEventFixDone);
+        }
     }
+}
+
+static bool app_custom_event_callback(void* context, uint32_t event) {
+    FakeChipApp* app = context;
+    if(event == AppEventFixDone) {
+        // Straight into a rescan with no further keypress. Whoever pressed OK
+        // has just finished moving a wire with one hand and holding the sensor
+        // with the other; asking for one more press is asking them to let go.
+        app_start_scan(app);
+        app_switch_view(app, FakeChipViewScan);
+        return true;
+    }
+    return false;
 }
 
 /* ---------------- Wiring enter/exit ---------------- */
@@ -1023,6 +1649,43 @@ static void wiring_exit_callback(void* context) {
 
 /* ---------------- Detail screen ---------------- */
 
+// Which parts the address could be holding. Only the ones with no ID register
+// can be listed: the other way to land on VerdictAmbiguous is two chips whose
+// ID checks both passed, and those are not recorded anywhere by the time this
+// draws. The count in the identification covers that case, so this returns to
+// it when it has no names to offer.
+//
+// Names are dropped from the end once the line is full rather than skipped over
+// to fit a shorter one further down: a list printed in an order that matches
+// nothing is worse than a short list that says how much it left out.
+static uint8_t detail_draw_candidates(Canvas* canvas, const I2CFoundDevice* dev, uint8_t y) {
+    const ChipEntry* cands[CHIP_MAX_ADDRS] = {0};
+    const size_t total = chip_db_no_id_at(dev->addr, cands, COUNT_OF(cands));
+    char buf[48];
+
+    if(total != dev->ident.candidates || total == 0) {
+        snprintf(buf, sizeof(buf), "%u parts fit, none named.", (unsigned)dev->ident.candidates);
+        canvas_draw_str(canvas, 2, y, buf);
+        return 9;
+    }
+
+    const uint16_t budget = 126 - canvas_string_width(canvas, " +9");
+    size_t used = (size_t)snprintf(buf, sizeof(buf), "Fits:");
+    size_t shown = 0;
+    for(size_t i = 0; i < total && i < COUNT_OF(cands); i++) {
+        snprintf(buf + used, sizeof(buf) - used, " %s", cands[i]->name);
+        if(canvas_string_width(canvas, buf) > budget) {
+            buf[used] = '\0';
+            break;
+        }
+        used = strlen(buf);
+        shown++;
+    }
+    if(shown < total) snprintf(buf + used, sizeof(buf) - used, " +%u", (unsigned)(total - shown));
+    canvas_draw_str(canvas, 2, y, buf);
+    return 9;
+}
+
 static void detail_draw_callback(Canvas* canvas, void* model) {
     DetailViewModel* m = model;
     const I2CFoundDevice* dev = &m->device;
@@ -1035,7 +1698,9 @@ static void detail_draw_callback(Canvas* canvas, void* model) {
         sizeof(buf),
         "0x%02X  %s",
         dev->addr,
-        dev->ident.chip ? dev->ident.chip->name : "UNKNOWN");
+        dev->ident.chip                        ? dev->ident.chip->name :
+        dev->ident.verdict == VerdictAmbiguous ? "AMBIGUOUS" :
+                                                 "UNKNOWN");
     canvas_draw_str(canvas, 2, 10, buf);
 
     canvas_set_font(canvas, FontSecondary);
@@ -1071,6 +1736,9 @@ static void detail_draw_callback(Canvas* canvas, void* model) {
         canvas_draw_str(canvas, 2, 20, "This chip has no ID reg:");
         canvas_draw_str(canvas, 2, 29, "only presence is proven.");
         y = 38;
+    }
+    if(dev->ident.verdict == VerdictAmbiguous && y <= 45) {
+        y += detail_draw_candidates(canvas, dev, y);
     }
     if(any_read_failed && y <= 45) {
         canvas_draw_str(canvas, 2, y, "Answers, but reads fail.");
@@ -1529,17 +2197,63 @@ static void settings_build(FakeChipApp* app) {
 
 #define CHIPS_LIST_ROWS 4
 
+// The list is every I2C chip, then every 1-Wire family. Both are things the
+// app can name off the bus, so leaving either out of "what do you know?"
+// under-reports it — a user with a DS18B20 who does not find it here concludes
+// the app cannot identify it, when it can.
+static size_t chips_total(void) {
+    return chip_db_count() + onewire_family_count();
+}
+
+// One row, whichever table it comes from; every out parameter may be NULL.
+// is_onewire also decides the heading, because the two buses do not carry the
+// same promise: an I2C part can be called GENUINE off its ID register, a
+// 1-Wire ROM can be replayed by any microcontroller and never is.
+static bool chips_row(size_t idx, const char** name, const char** kind, bool* is_onewire) {
+    const char* row_name;
+    const char* row_kind;
+    bool row_onewire;
+
+    size_t i2c_count = chip_db_count();
+    if(idx < i2c_count) {
+        const ChipEntry* chip = chip_db_get(idx);
+        if(!chip) return false;
+        row_name = chip->name;
+        row_kind = chip->kind;
+        row_onewire = false;
+    } else {
+        const OneWireFamily* family = onewire_family_get(idx - i2c_count);
+        if(!family) return false;
+        row_name = family->name;
+        row_kind = family->kind;
+        row_onewire = true;
+    }
+
+    if(name) *name = row_name;
+    if(kind) *kind = row_kind;
+    if(is_onewire) *is_onewire = row_onewire;
+    return true;
+}
+
 // Answers "what does this thing actually know?", and doubles as the place
 // where every name and description is shown at full width — if one of them
 // were too long for the screen, it would be obvious here.
 static void chips_draw_callback(Canvas* canvas, void* model) {
     ChipsViewModel* m = model;
-    size_t total = chip_db_count();
+    size_t total = chips_total();
     canvas_clear(canvas);
+
+    const char* sel_name = NULL;
+    const char* sel_kind = NULL;
+    bool sel_onewire = false;
+    bool have_sel = chips_row(m->selected, &sel_name, &sel_kind, &sel_onewire);
 
     char buf[24];
     canvas_set_font(canvas, FontPrimary);
-    canvas_draw_str(canvas, 2, 10, "Known chips");
+    // The heading follows the selection rather than sitting still: scrolling
+    // off the end of the I2C table into the 1-Wire families is otherwise
+    // invisible, and the two are not interchangeable.
+    canvas_draw_str(canvas, 2, 10, sel_onewire ? "1-Wire parts" : "Known chips");
     canvas_set_font(canvas, FontSecondary);
     snprintf(buf, sizeof(buf), "%u/%u", (unsigned)m->selected + 1, (unsigned)total);
     canvas_draw_str_aligned(canvas, 126, 10, AlignRight, AlignBottom, buf);
@@ -1549,25 +2263,24 @@ static void chips_draw_callback(Canvas* canvas, void* model) {
 
     for(uint8_t row = 0; row < CHIPS_LIST_ROWS; row++) {
         size_t idx = first + row;
-        if(idx >= total) break;
-        const ChipEntry* chip = chip_db_get(idx);
+        const char* name = NULL;
+        if(idx >= total || !chips_row(idx, &name, NULL, NULL)) break;
         uint8_t y = 22 + row * 10;
         bool sel = (idx == m->selected);
         if(sel) {
             canvas_draw_box(canvas, 0, y - 8, 128, 10);
             canvas_set_color(canvas, ColorWhite);
         }
-        canvas_draw_str(canvas, 4, y, chip->name);
+        canvas_draw_str(canvas, 4, y, name);
         if(sel) canvas_set_color(canvas, ColorBlack);
     }
 
     // The description gets a line of its own. Packing it beside the name made
     // the two collide as soon as either was long.
-    const ChipEntry* current = chip_db_get(m->selected);
-    if(current) {
+    if(have_sel) {
         canvas_draw_box(canvas, 0, 55, 128, 9);
         canvas_set_color(canvas, ColorWhite);
-        canvas_draw_str_aligned(canvas, 64, 62, AlignCenter, AlignBottom, current->kind);
+        canvas_draw_str_aligned(canvas, 64, 62, AlignCenter, AlignBottom, sel_kind);
         canvas_set_color(canvas, ColorBlack);
     }
 }
@@ -1580,7 +2293,7 @@ static bool chips_input_callback(InputEvent* event, void* context) {
         app->chips_view,
         ChipsViewModel * m,
         {
-            size_t total = chip_db_count();
+            size_t total = chips_total();
             if(event->key == InputKeyUp && m->selected > 0) {
                 m->selected--;
                 consumed = true;
@@ -1877,6 +2590,81 @@ static void test_help_draw_callback(Canvas* canvas, void* model) {
     canvas_draw_str(canvas, 2, 62, "Template + guide: see repo");
 }
 
+/* ---------------- UART self-test ---------------- */
+
+static void selftest_draw_callback(Canvas* canvas, void* model) {
+    SelftestViewModel* m = model;
+    canvas_clear(canvas);
+
+    canvas_set_font(canvas, FontPrimary);
+    canvas_draw_str(canvas, 2, 10, "UART self-test");
+
+    // The setup stays on screen beside the result rather than being replaced by
+    // it. It is what makes a failure actionable, and it is also the whole answer
+    // to the blocked state, so clearing it the moment a result arrives would
+    // take away the fix at the exact moment it is needed.
+    canvas_set_font(canvas, FontSecondary);
+    canvas_draw_str(canvas, 2, 22, "Jumper pin 15 to pin 16,");
+    canvas_draw_str(canvas, 2, 31, "nothing else on the bus.");
+
+    canvas_draw_line(canvas, 0, 36, 128, 36);
+
+    const char* headline;
+    const char* detail = m->detail;
+    if(m->running) {
+        headline = "Running...";
+        detail = "";
+    } else if(m->state == I2CSelftestPassed) {
+        headline = "Passed";
+    } else if(m->state == I2CSelftestFailed) {
+        headline = "Failed";
+    } else if(m->state == I2CSelftestBlocked) {
+        // Deliberately not "Failed". Nothing was measured, so nothing failed.
+        headline = "Not run";
+    } else {
+        headline = "Not run yet";
+        detail = "Press OK to start";
+    }
+
+    canvas_set_font(canvas, FontPrimary);
+    canvas_draw_str(canvas, 2, 48, headline);
+    canvas_set_font(canvas, FontSecondary);
+    canvas_draw_str(canvas, 2, 59, detail);
+}
+
+static bool selftest_input_callback(InputEvent* event, void* context) {
+    FakeChipApp* app = context;
+    if(event->type == InputTypeShort && event->key == InputKeyOk) {
+        // Everything else the worker does owns these same two pins. Nothing
+        // reaches this screen while one of them is running, but queueing behind
+        // one would start the test at some unpredictable later moment, and a
+        // self-test that runs when it was not asked for is worse than one that
+        // declines.
+        if(i2c_worker_is_busy(app->worker)) return true;
+        with_view_model(app->selftest_view, SelftestViewModel * m, { m->running = true; }, true);
+        i2c_worker_selftest_start(app->worker);
+        return true;
+    }
+    return false;
+}
+
+static void selftest_enter_callback(void* context) {
+    FakeChipApp* app = context;
+    char detail[I2C_SELFTEST_DETAIL_SIZE];
+    I2CSelftestState state = i2c_worker_get_selftest(app->worker, detail, sizeof(detail));
+    // running is left alone on purpose: a test still in flight because the user
+    // walked out and back in is still in flight, and the done event clears it
+    // wherever they happen to be standing.
+    with_view_model(
+        app->selftest_view,
+        SelftestViewModel * m,
+        {
+            m->state = (uint8_t)state;
+            snprintf(m->detail, sizeof(m->detail), "%s", detail);
+        },
+        true);
+}
+
 /* ---------------- Report viewer ---------------- */
 
 // The file on the SD card is for later. What matters at the front door is a
@@ -1896,7 +2684,7 @@ static void app_show_report(FakeChipApp* app, bool disputed) {
 
     DateTime dt;
     furi_hal_rtc_get_datetime(&dt);
-    report_build(app->report_text, snapshot, count, disputed, &dt);
+    report_build(app->report_text, snapshot, count, disputed, &dt, NULL);
     free(snapshot);
 
     app_present_report(app, nav_to_scan);
@@ -2143,6 +2931,8 @@ static void onewire_enter(void* context) {
             m->selected = 0;
             m->busy = true;
             m->explain = false;
+            m->saved_name[0] = '\0';
+            m->save_failed = false;
         },
         true);
 
@@ -2160,6 +2950,34 @@ static void onewire_exit(void* context) {
     app->ow_thread = NULL;
 }
 
+// Same rule as the scan side: snapshot the result, then build and write the
+// report outside the model lock. An SD write can stall for seconds and the GUI
+// must not be holding the mutex while it does.
+static void onewire_save_log(FakeChipApp* app) {
+    OneWireScanResult* snapshot = malloc(sizeof(OneWireScanResult));
+    with_view_model(app->onewire_view, OneWireViewModel * m, { *snapshot = m->res; }, false);
+
+    DateTime dt;
+    furi_hal_rtc_get_datetime(&dt);
+
+    FuriString* text = furi_string_alloc();
+    report_build_onewire(text, snapshot, &dt);
+    free(snapshot);
+
+    char name[SAVED_NAME_LEN] = {0};
+    bool saved = report_save_text(text, &dt, name, sizeof(name));
+    furi_string_free(text);
+
+    with_view_model(
+        app->onewire_view,
+        OneWireViewModel * m,
+        {
+            snprintf(m->saved_name, sizeof(m->saved_name), "%s", saved ? name : "");
+            m->save_failed = !saved;
+        },
+        true);
+}
+
 // 16 hex digits with no separators: it is an identifier to compare, not prose.
 static void ow_format_rom(const uint8_t* rom, char out[17]) {
     for(uint8_t i = 0; i < 8; i++) {
@@ -2171,6 +2989,31 @@ static void onewire_draw_callback(Canvas* canvas, void* model) {
     OneWireViewModel* m = model;
     canvas_clear(canvas);
     canvas_set_font(canvas, FontPrimary);
+
+    // Saving a file and not saying where it went is not saving it — and a
+    // write that failed has to say so just as plainly, or the user leaves
+    // holding evidence that was never written.
+    if(m->saved_name[0] || m->save_failed) {
+        if(m->save_failed) {
+            canvas_draw_str_aligned(canvas, 64, 14, AlignCenter, AlignBottom, "SAVE FAILED");
+            canvas_set_font(canvas, FontSecondary);
+            canvas_draw_str_aligned(
+                canvas, 64, 30, AlignCenter, AlignBottom, "The SD card did not take");
+            canvas_draw_str_aligned(
+                canvas, 64, 41, AlignCenter, AlignBottom, "the file. Card missing,");
+            canvas_draw_str_aligned(canvas, 64, 52, AlignCenter, AlignBottom, "or out of space?");
+        } else {
+            canvas_draw_str_aligned(canvas, 64, 14, AlignCenter, AlignBottom, "REPORT SAVED");
+            canvas_set_font(canvas, FontSecondary);
+            canvas_draw_str_aligned(canvas, 64, 27, AlignCenter, AlignBottom, m->saved_name);
+            canvas_draw_str_aligned(
+                canvas, 64, 40, AlignCenter, AlignBottom, "On the SD card, in");
+            canvas_draw_str_aligned(canvas, 64, 49, AlignCenter, AlignBottom, "apps_data/");
+            canvas_draw_str_aligned(
+                canvas, 64, 58, AlignCenter, AlignBottom, "fake_chip_detector");
+        }
+        return;
+    }
 
     // Saying "IDs are copyable" and leaving it there would be worse than not
     // saying it: the whole point of the app is that the user understands what
@@ -2207,6 +3050,13 @@ static void onewire_draw_callback(Canvas* canvas, void* model) {
             canvas_draw_str(canvas, 2, 34, "Data to pin 17, plus 3V3,");
             canvas_draw_str(canvas, 2, 44, "GND and a 4.7k pull-up.");
         }
+        // Saving matters most here, not least. The person holding a part that
+        // said nothing at all is the one being asked to accept or refuse a
+        // parcel with no evidence either way, and the report has something to
+        // give them: whether the line was held low, which is usually their own
+        // wiring, or whether it was idle and simply nobody answered. There is
+        // no OK action on this screen, so the bar carries only the save hint.
+        draw_action_bar(canvas, "", true);
         return;
     }
 
@@ -2243,13 +3093,20 @@ static void onewire_draw_callback(Canvas* canvas, void* model) {
         if(tenths < -550 || tenths > 1250) {
             canvas_draw_str(canvas, 2, 43, "Reading out of range.");
         } else {
+            // The sign is printed on its own, not carried by tenths/10. C
+            // truncates toward zero, so anything from -0.9 to -0.1 C has a
+            // whole part of 0 -- and "0" has no minus in it. Formatted the
+            // obvious way, a sensor sitting at half a degree below freezing
+            // reported half a degree above it.
+            int mag = tenths < 0 ? -tenths : tenths;
             char line[26];
             snprintf(
                 line,
                 sizeof(line),
-                "Reads %d.%d C - it works",
-                tenths / 10,
-                (tenths < 0 ? -tenths : tenths) % 10);
+                "Reads %s%d.%d C - it works",
+                tenths < 0 ? "-" : "",
+                mag / 10,
+                mag % 10);
             canvas_draw_str(canvas, 2, 43, line);
         }
     } else if(dev->measured) {
@@ -2258,21 +3115,39 @@ static void onewire_draw_callback(Canvas* canvas, void* model) {
         canvas_draw_str(canvas, 2, 43, "Present, ID checks out.");
     }
 
-    draw_action_bar(canvas, "OK: what this proves", false);
+    // Shorter than the "OK: what this proves" this screen used to say: the
+    // save hint and its key glyph now take the right-hand end of the bar, and
+    // the only other call that offers save gets by with a label this length.
+    draw_action_bar(canvas, "OK: explain", true);
 }
 
 static bool onewire_input_callback(InputEvent* event, void* context) {
     FakeChipApp* app = context;
     if(event->type != InputTypeShort && event->type != InputTypeRepeat) return false;
     bool consumed = false;
+    bool do_save = false;
     with_view_model(
         app->onewire_view,
         OneWireViewModel * m,
         {
-            if(m->explain) {
+            if(m->saved_name[0] || m->save_failed) {
+                // any key dismisses the save confirmation, Back included, so
+                // the first Back returns to the result rather than the menu
+                m->saved_name[0] = '\0';
+                m->save_failed = false;
+                consumed = true;
+            } else if(m->explain) {
                 // Any key closes the panel, Back included — consuming it here
                 // means the first Back returns to the result, not to the menu.
+                // Checked before the save key so that promise stays literal.
                 m->explain = false;
+                consumed = true;
+            } else if(event->key == InputKeyRight && !m->busy && event->type == InputTypeShort) {
+                // Deliberately not gated on a device having been found: an
+                // empty bus is a result too, and it is the one its owner most
+                // needs written down. Gated on !busy so a half-finished scan
+                // can never be filed as a finished one.
+                do_save = true;
                 consumed = true;
             } else if(event->key == InputKeyUp && m->selected > 0) {
                 m->selected--;
@@ -2286,6 +3161,11 @@ static bool onewire_input_callback(InputEvent* event, void* context) {
             }
         },
         consumed);
+
+    if(do_save) {
+        onewire_save_log(app);
+        i2c_notify_play(app->notifications, I2CNotifyNeutral);
+    }
     return consumed;
 }
 
@@ -2328,6 +3208,9 @@ static int32_t anim_thread_worker(void* context) {
         case FakeChipViewLive:
             with_view_model(app->live_view, LiveViewModel * m, { m->frame++; }, true);
             break;
+        case FakeChipViewSilent:
+            with_view_model(app->silent_view, SilentViewModel * m, { m->frame++; }, true);
+            break;
         default:
             break; // menus and static screens need no ticks
         }
@@ -2351,6 +3234,9 @@ static void menu_callback(void* context, uint32_t index) {
         break;
     case MenuIndexTests:
         app_switch_view(app, FakeChipViewTests);
+        break;
+    case MenuIndexSelftest:
+        app_switch_view(app, FakeChipViewSelftest);
         break;
     case MenuIndexSettings:
         app_switch_view(app, FakeChipViewSettings);
@@ -2435,6 +3321,8 @@ static FakeChipApp* fake_chip_app_alloc(void) {
     app->notifications = furi_record_open(RECORD_NOTIFICATION);
     app->view_dispatcher = view_dispatcher_alloc();
     view_dispatcher_attach_to_gui(app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);
+    view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
+    view_dispatcher_set_custom_event_callback(app->view_dispatcher, app_custom_event_callback);
     app->current_view = FakeChipViewMenu;
 
     if(app->settings.backlight) {
@@ -2450,6 +3338,7 @@ static FakeChipApp* fake_chip_app_alloc(void) {
     submenu_add_item(app->submenu, "Scan I2C bus", MenuIndexScan, menu_callback, app);
     submenu_add_item(app->submenu, "Scan 1-Wire", MenuIndexOneWire, menu_callback, app);
     submenu_add_item(app->submenu, "Live tests", MenuIndexTests, menu_callback, app);
+    submenu_add_item(app->submenu, "UART self-test", MenuIndexSelftest, menu_callback, app);
     submenu_add_item(app->submenu, "Settings", MenuIndexSettings, menu_callback, app);
     submenu_add_item(app->submenu, "Known chips", MenuIndexChips, menu_callback, app);
     submenu_add_item(app->submenu, "Saved reports", MenuIndexSaved, menu_callback, app);
@@ -2521,6 +3410,15 @@ static FakeChipApp* fake_chip_app_alloc(void) {
     view_set_previous_callback(app->test_help_view, nav_to_tests);
     view_dispatcher_add_view(app->view_dispatcher, FakeChipViewTestHelp, app->test_help_view);
 
+    app->selftest_view = view_alloc();
+    view_set_context(app->selftest_view, app);
+    view_allocate_model(app->selftest_view, ViewModelTypeLocking, sizeof(SelftestViewModel));
+    view_set_draw_callback(app->selftest_view, selftest_draw_callback);
+    view_set_input_callback(app->selftest_view, selftest_input_callback);
+    view_set_enter_callback(app->selftest_view, selftest_enter_callback);
+    view_set_previous_callback(app->selftest_view, nav_to_menu);
+    view_dispatcher_add_view(app->view_dispatcher, FakeChipViewSelftest, app->selftest_view);
+
     app->chips_view = view_alloc();
     view_set_context(app->chips_view, app);
     view_allocate_model(app->chips_view, ViewModelTypeLocking, sizeof(ChipsViewModel));
@@ -2538,6 +3436,16 @@ static FakeChipApp* fake_chip_app_alloc(void) {
     view_set_exit_callback(app->onewire_view, onewire_exit);
     view_set_previous_callback(app->onewire_view, nav_to_menu);
     view_dispatcher_add_view(app->view_dispatcher, FakeChipViewOneWire, app->onewire_view);
+
+    app->silent_view = view_alloc();
+    view_set_context(app->silent_view, app);
+    view_allocate_model(app->silent_view, ViewModelTypeLocking, sizeof(SilentViewModel));
+    view_set_draw_callback(app->silent_view, silent_draw_callback);
+    view_set_input_callback(app->silent_view, silent_input_callback);
+    view_set_enter_callback(app->silent_view, silent_enter_callback);
+    view_set_exit_callback(app->silent_view, silent_exit_callback);
+    view_set_previous_callback(app->silent_view, nav_to_scan);
+    view_dispatcher_add_view(app->view_dispatcher, FakeChipViewSilent, app->silent_view);
 
     app->saved_view = view_alloc();
     view_set_context(app->saved_view, app);
@@ -2563,8 +3471,17 @@ static FakeChipApp* fake_chip_app_alloc(void) {
     widget_add_string_element(
         app->about_widget, 64, 30, AlignCenter, AlignTop, FontSecondary, "by their ID registers.");
     {
+        // Two numbers rather than one total: they are not the same kind of
+        // knowledge. An I2C chip is named from an ID register the app reads
+        // back; a 1-Wire part is named from a family code that identifies the
+        // part without vouching for it.
         static char db_line[32];
-        snprintf(db_line, sizeof(db_line), "%u chips known", (unsigned)chip_db_count());
+        snprintf(
+            db_line,
+            sizeof(db_line),
+            "%u I2C + %u 1-Wire known",
+            (unsigned)chip_db_count(),
+            (unsigned)onewire_family_count());
         widget_add_string_element(
             app->about_widget, 64, 42, AlignCenter, AlignTop, FontSecondary, db_line);
     }
@@ -2613,8 +3530,10 @@ static void fake_chip_app_free(FakeChipApp* app) {
     view_dispatcher_remove_view(app->view_dispatcher, FakeChipViewReport);
     view_dispatcher_remove_view(app->view_dispatcher, FakeChipViewSaved);
     view_dispatcher_remove_view(app->view_dispatcher, FakeChipViewOneWire);
+    view_dispatcher_remove_view(app->view_dispatcher, FakeChipViewSilent);
     view_dispatcher_remove_view(app->view_dispatcher, FakeChipViewTests);
     view_dispatcher_remove_view(app->view_dispatcher, FakeChipViewTestHelp);
+    view_dispatcher_remove_view(app->view_dispatcher, FakeChipViewSelftest);
     view_dispatcher_remove_view(app->view_dispatcher, FakeChipViewAbout);
     submenu_free(app->submenu);
     view_free(app->wiring_view);
@@ -2623,9 +3542,11 @@ static void fake_chip_app_free(FakeChipApp* app) {
     view_free(app->live_view);
     view_free(app->tests_view);
     view_free(app->test_help_view);
+    view_free(app->selftest_view);
     view_free(app->chips_view);
     view_free(app->saved_view);
     view_free(app->onewire_view);
+    view_free(app->silent_view);
     text_box_free(app->report_box);
     furi_string_free(app->report_text);
     variable_item_list_free(app->settings_list);

--- a/non_catalog_apps/fake_chip_detector/i2c_worker.c
+++ b/non_catalog_apps/fake_chip_detector/i2c_worker.c
@@ -3,14 +3,41 @@
 #include <furi.h>
 #include <furi_hal_i2c.h>
 #include <furi_hal_gpio.h>
+#include <furi_hal_power.h>
 #include <furi_hal_resources.h>
 
 #define TAG "I2CWorker"
 
-#define WORKER_FLAG_SCAN  (1UL << 0)
-#define WORKER_FLAG_EXIT  (1UL << 1)
-#define WORKER_FLAG_WATCH (1UL << 3)
-#define WORKER_FLAG_ALL   (WORKER_FLAG_SCAN | WORKER_FLAG_EXIT | WORKER_FLAG_WATCH)
+#define WORKER_FLAG_SCAN     (1UL << 0)
+#define WORKER_FLAG_EXIT     (1UL << 1)
+#define WORKER_FLAG_WATCH    (1UL << 3)
+#define WORKER_FLAG_PAD      (1UL << 4)
+#define WORKER_FLAG_FIX      (1UL << 5)
+#define WORKER_FLAG_SELFTEST (1UL << 6)
+#define WORKER_FLAG_ALL                                                          \
+    (WORKER_FLAG_SCAN | WORKER_FLAG_EXIT | WORKER_FLAG_WATCH | WORKER_FLAG_PAD | \
+     WORKER_FLAG_FIX | WORKER_FLAG_SELFTEST)
+
+// How many agreeing reads it takes to move the pad meter. At 50ms a read that
+// is a fifth of a second of steadiness, which is short enough to feel live and
+// long enough that a hand near a floating pad does not make it flicker.
+#define PAD_SETTLE_READS 4
+
+// How long to spend trying to cut the rail from software before asking the
+// person to do it. Measured on a Flipper Zero running Unleashed 0.90 with the
+// bench on USB: furi_hal_power_disable_external_3_3v() does not de-power header
+// pin 9 at all. The module's pull-up survived a 800ms outage sampled every
+// 20ms, a 512-byte SD sector read succeeded 300ms in, and a VL6180X parked at a
+// non-default address by register 0x0212 -- a value that cannot survive a
+// power-on reset -- kept it. Re-issuing the call every 20ms changed nothing.
+// The attempt stays because that was one device on one firmware, but nothing
+// downstream may assume it worked: the lines have to be seen falling.
+#define RAIL_TRY_MS   300
+#define POWER_BOOT_MS 650
+
+// Agreeing reads before the strap is called applied or lost. The pull is weak
+// and the pad may be capacitive, so give it a moment before judging.
+#define STRAP_SETTLE_READS 3
 
 struct I2CWorker {
     FuriThread* thread;
@@ -19,9 +46,20 @@ struct I2CWorker {
     void* callback_context;
     volatile bool busy;
     volatile bool watch_stop;
+    volatile bool pad_stop;
+    volatile bool fix_stop;
     volatile bool scan_abort;
+    volatile uint8_t pad_level; // I2CPadLevel
+    volatile uint8_t fix_stage; // I2CFixStage
+    volatile uint32_t fix_gen; // bumped per run so an abandoned one cannot resume
+    volatile bool fix_want_high; // level the pad has to sit at for I2C
     volatile uint32_t probe_timeout_ms;
     volatile uint8_t progress_addr;
+    volatile bool listening; // the sweep is over and the serial line is being heard out
+    volatile uint8_t listen_outcome; // UartListenOutcome
+    UartListenResult listen;
+    volatile uint8_t selftest_state; // I2CSelftestState
+    char selftest_detail[I2C_SELFTEST_DETAIL_SIZE];
     I2CFoundDevice found[I2C_SCAN_MAX_FOUND];
     size_t found_count;
     I2CBusCheck bus;
@@ -114,12 +152,21 @@ void i2c_worker_check_bus(I2CBusCheck* out) {
     out->powered = out->scl_ok || out->sda_ok;
 
     if(scl_stuck || sda_stuck) {
+        // No short test on this branch: a line already held low follows the
+        // clock whatever the other line does, so the answer would be yes for a
+        // reason that has nothing to do with a short.
         out->health = I2CBusStuckLow;
     } else if(out->scl_ok && out->sda_ok) {
         out->health = I2CBusOk; // both lines are needed before I2C can work
         out->shorted = i2c_lines_shorted();
     } else {
         out->health = I2CBusFloating;
+        // Two bare wires touching each other have no pull-ups between them, so
+        // a plain SDA-to-SCL short lands here rather than on the branch above --
+        // and while this test only ran up there, the app could not see the
+        // easiest mistake to make with four loose wires. TESTING.md has been
+        // promising it since before it was true.
+        out->shorted = i2c_lines_shorted();
         // Any incomplete bus is worth checking, not just a completely dead
         // one: with SDA on the right pin and SCL on the wrong one, the old
         // "both lines dead" condition never fired and the user got no hint.
@@ -217,6 +264,20 @@ static void i2c_worker_notify(I2CWorker* worker, I2CWorkerEvent event) {
     if(worker->callback) worker->callback(event, worker->callback_context);
 }
 
+// Rates worth trying, commonest first. Not a guess between them: a wrong rate
+// turns real traffic into framing errors rather than into silence, so the
+// sweep can tell "wrong rate" from "nothing there" and picks its winner on
+// that evidence.
+static const uint32_t LISTEN_BAUDS[] = {9600, 115200, 38400, 57600};
+
+// Per rate, so about two seconds in all -- spent only on a sweep that has
+// already failed, and while the screen says what it is doing. Not longer,
+// because this sits between somebody and their answer. And not treated as
+// exhaustive either: a GPS module bursts once a second and can fall between
+// two windows this size, which is why nothing downstream is allowed to say
+// the part is silent, only that nothing was heard.
+#define LISTEN_WINDOW_MS 450
+
 static void i2c_worker_do_scan(I2CWorker* worker) {
     // Electrical state first: it explains an empty sweep far better than
     // "no devices found" on its own.
@@ -226,6 +287,11 @@ static void i2c_worker_do_scan(I2CWorker* worker) {
     furi_mutex_acquire(worker->mutex, FuriWaitForever);
     worker->found_count = 0;
     worker->bus = check;
+    // Cleared here, not after the listen: a result carried over from the
+    // previous scan would sit on screen beside a fresh sweep as though it had
+    // just been measured.
+    worker->listen_outcome = UartListenUnavailable;
+    memset(&worker->listen, 0, sizeof(worker->listen));
     furi_mutex_release(worker->mutex);
 
     for(uint8_t addr = I2C_SCAN_ADDR_FIRST; addr <= I2C_SCAN_ADDR_LAST; addr++) {
@@ -245,6 +311,38 @@ static void i2c_worker_do_scan(I2CWorker* worker) {
             furi_mutex_release(worker->mutex);
         }
         if((addr & 0x07) == 0) i2c_worker_notify(worker, I2CWorkerEventScanProgress);
+    }
+
+    furi_mutex_acquire(worker->mutex, FuriWaitForever);
+    bool empty = worker->found_count == 0;
+    furi_mutex_release(worker->mutex);
+
+    // Nothing answered, and the bus itself was fine: powered, both pull-ups
+    // there, both lines idle high. That is the shape of a part strapped off
+    // the I2C bus rather than a part that is dead, so before the screen says
+    // anything, listen on the same two wires. LPUART is on PC0 and PC1, which
+    // are pins 16 and 15 -- nothing has to be re-plugged.
+    //
+    // The health gate is not only about relevance, it is the noise guard.
+    // With the module's pull-ups present the receive pin idles high, so a
+    // framing error means real edges arrived. On a floating bus the pin drifts
+    // and drift alone can raise framing errors, which the sweep reports as
+    // "something was transmitting". Listening off a dead bus would invent
+    // traffic out of nothing, on the one screen where a user is least able to
+    // argue back.
+    if(!worker->scan_abort && empty && check.health == I2CBusOk) {
+        worker->listening = true;
+        i2c_worker_notify(worker, I2CWorkerEventScanProgress);
+
+        UartListenResult result;
+        UartListenOutcome outcome = uart_listen_sweep(
+            LISTEN_BAUDS, COUNT_OF(LISTEN_BAUDS), LISTEN_WINDOW_MS, &worker->scan_abort, &result);
+
+        furi_mutex_acquire(worker->mutex, FuriWaitForever);
+        worker->listen = result;
+        worker->listen_outcome = (uint8_t)outcome;
+        furi_mutex_release(worker->mutex);
+        worker->listening = false;
     }
 }
 
@@ -266,6 +364,216 @@ static void i2c_worker_do_watch(I2CWorker* worker) {
     }
 }
 
+// The pad meter. Deliberately the same measurement the bus check already
+// makes, pointed at whatever the user has walked the pin-15 wire onto: the
+// internal pulls are ~40k, so anything actually driving the pad or tying it to
+// a rail wins, and a pad connected to nothing shows as floating.
+static I2CPadLevel i2c_pad_read(void) {
+    bool stuck_low = false;
+    bool high_against_pulldown = i2c_line_probe(&gpio_ext_pc1, &stuck_low);
+    if(stuck_low) return I2CPadLow;
+    if(high_against_pulldown) return I2CPadHigh;
+    return I2CPadFloating;
+}
+
+static void i2c_worker_do_pad_watch(I2CWorker* worker) {
+    I2CPadLevel shown = (I2CPadLevel)worker->pad_level;
+    I2CPadLevel candidate = shown;
+    uint8_t agreed = 0;
+
+    while(!worker->pad_stop) {
+        I2CPadLevel now = i2c_pad_read();
+        if(now == candidate) {
+            if(agreed < PAD_SETTLE_READS) agreed++;
+        } else {
+            candidate = now;
+            agreed = 1;
+        }
+        if(agreed >= PAD_SETTLE_READS && candidate != shown) {
+            shown = candidate;
+            worker->pad_level = (uint8_t)shown;
+            i2c_worker_notify(worker, I2CWorkerEventPadUpdate);
+        }
+        furi_delay_ms(50);
+    }
+}
+
+/* ---- the fix run ---- */
+
+// Is the run that owns this generation still the one the screen is waiting on?
+//
+// fix_stop alone is not enough. Leaving the screen sets it, but starting a new
+// run clears it again, and a run can be up to POWER_BOOT_MS deep in a delay it
+// cannot check anything from. Back then OK inside that window would clear the
+// stop out from under the old run, which would wake up believing it was still
+// current and walk the user through the tail of a fix they had abandoned -
+// including the automatic rescan at the end of it. The generation only ever
+// moves forward, so an old run can never mistake itself for the new one.
+static bool fix_current(I2CWorker* worker, uint32_t gen) {
+    return !worker->fix_stop && worker->fix_gen == gen;
+}
+
+static void fix_set(I2CWorker* worker, uint32_t gen, I2CFixStage stage) {
+    // Silent once the screen has walked away. Several steps here cannot be
+    // interrupted mid-measurement, so a stop can arrive while one is still
+    // finishing; announcing the next stage afterwards would drag the user back
+    // into a screen they just left, and the last of those stages would kick off
+    // a rescan nobody asked for.
+    if(!fix_current(worker, gen)) return;
+    worker->fix_stage = (uint8_t)stage;
+    i2c_worker_notify(worker, I2CWorkerEventFixUpdate);
+}
+
+// The strap. Weak on purpose: the internal pull is ~40k, which is enough to
+// hold a high-impedance mode input but cannot fight a driver, so if the wire
+// turns out to be sitting on an output the two never argue. It also cannot
+// back-feed enough current through an unpowered chip's protection diode to keep
+// the part alive across the power cycle that follows, which a push-pull output
+// on the same pin could.
+static void fix_strap_apply(bool want_high) {
+    furi_hal_gpio_init(
+        &gpio_ext_pc1, GpioModeInput, want_high ? GpioPullUp : GpioPullDown, GpioSpeedLow);
+}
+
+static void fix_strap_release(void) {
+    furi_hal_gpio_init(&gpio_ext_pc1, GpioModeAnalog, GpioPullNo, GpioSpeedLow);
+}
+
+// Reading the pin back is the whole point. A pad tied the wrong way in copper
+// wins against the internal pull, and saying so is worth far more than a fix
+// that quietly does nothing: it tells the buyer the board decided this, not
+// them.
+static bool fix_strap_took(bool want_high) {
+    furi_delay_ms(20);
+    for(uint8_t i = 0; i < STRAP_SETTLE_READS; i++) {
+        if(furi_hal_gpio_read(&gpio_ext_pc1) != want_high) return false;
+        furi_delay_ms(10);
+    }
+    return true;
+}
+
+// SCL only. Pin 15 is holding the strap, so the module's other pull-up is the
+// one thing left that still reports whether it has power.
+static bool fix_module_powered(void) {
+    bool stuck = false;
+    return i2c_line_probe(&gpio_ext_pc0, &stuck);
+}
+
+// Waits for the module's power to go the way asked. Returns false if the view
+// went away, or was replaced by a newer run, while waiting.
+static bool fix_wait_power(I2CWorker* worker, uint32_t gen, bool want_powered) {
+    while(fix_current(worker, gen)) {
+        if(fix_module_powered() == want_powered) return true;
+        furi_delay_ms(50);
+    }
+    return false;
+}
+
+// Strap the pad, get the part restarted so the strap is actually sampled, then
+// get the wire back on the bus. Every step ends on a measurement rather than a
+// delay, and nothing here claims anything the app has not seen: if the rail
+// cannot be cut from software, the person is asked, and the app waits until the
+// pull-ups really do disappear.
+static void i2c_worker_do_fix(I2CWorker* worker) {
+    const uint32_t gen = worker->fix_gen;
+    bool want_high = worker->fix_want_high;
+
+    fix_set(worker, gen, I2CFixStrapping);
+    fix_strap_apply(want_high);
+    if(!fix_strap_took(want_high)) {
+        fix_strap_release();
+        fix_set(worker, gen, I2CFixPadHeld); // terminal: the screen offers the report
+        return;
+    }
+
+    // One quiet attempt at cutting the rail ourselves, so a device where that
+    // works never bothers its owner. Only counts if the module was powered to
+    // begin with and stopped being powered: a sensor that arrived here already
+    // dark would otherwise look like proof the cut worked, and the app would
+    // skip the one step that actually restarts the part.
+    bool powered_before = fix_module_powered();
+    bool fell = false;
+    if(powered_before) {
+        furi_hal_power_disable_external_3_3v();
+        for(uint32_t waited = 0; waited < RAIL_TRY_MS && fix_current(worker, gen); waited += 20) {
+            if(!fix_module_powered()) {
+                fell = true;
+                break;
+            }
+            furi_delay_ms(20);
+        }
+        furi_hal_power_enable_external_3_3v();
+    }
+
+    if(!fell) {
+        if(powered_before) {
+            fix_set(worker, gen, I2CFixWantPowerOff);
+            if(!fix_wait_power(worker, gen, false)) {
+                fix_strap_release();
+                return;
+            }
+        }
+        fix_set(worker, gen, I2CFixWantPowerOn);
+        if(!fix_wait_power(worker, gen, true)) {
+            fix_strap_release();
+            return;
+        }
+    }
+    furi_delay_ms(POWER_BOOT_MS);
+
+    // The strap has done its job the moment the part came up holding it: a mode
+    // pin is sampled at reset and kept. Let go before asking for the wire back,
+    // or the pull would fight the bus.
+    fix_strap_release();
+    fix_set(worker, gen, I2CFixWantWire);
+    while(fix_current(worker, gen)) {
+        I2CBusCheck bus;
+        i2c_worker_check_bus(&bus);
+        if(bus.health == I2CBusOk) {
+            fix_set(worker, gen, I2CFixDone);
+            return;
+        }
+        furi_delay_ms(100);
+    }
+}
+
+// The loopback proves the transport with one jumper and no sensor: expansion
+// service stood down, handle acquired, pinout as documented, framing, transmit,
+// the interrupt-context receive, clean release.
+static void i2c_worker_do_selftest(I2CWorker* worker) {
+    char detail[I2C_SELFTEST_DETAIL_SIZE];
+    uint8_t state;
+
+    // Anything at all on these two pins stops the run. A pull-up means a module
+    // is still wired up; a line held low means something is driving it, and
+    // this test drives pin 15 itself. Either way the fight would surface as a
+    // transport fault, which is the one wrong answer to give someone who came
+    // here to find out whether the transport works.
+    //
+    // The jumper alone does not trip this: i2c_line_probe leaves the other pin
+    // analog and unpulled while it reads, so the two float together rather than
+    // pulling against each other.
+    I2CBusCheck bus;
+    i2c_worker_check_bus(&bus);
+    if(bus.health == I2CBusStuckLow) {
+        state = I2CSelftestBlocked;
+        snprintf(detail, sizeof(detail), "A line is held low");
+    } else if(bus.powered) {
+        state = I2CSelftestBlocked;
+        snprintf(detail, sizeof(detail), "Pull-ups on pins 15/16");
+    } else {
+        // One rate is enough. What this proves is the path, and the path is the
+        // same at every rate; 115200 because the listen sweep leans on it.
+        bool ok = uart_selftest_loopback(115200, detail, sizeof(detail));
+        state = ok ? I2CSelftestPassed : I2CSelftestFailed;
+    }
+
+    furi_mutex_acquire(worker->mutex, FuriWaitForever);
+    snprintf(worker->selftest_detail, sizeof(worker->selftest_detail), "%s", detail);
+    worker->selftest_state = state;
+    furi_mutex_release(worker->mutex);
+}
+
 static int32_t i2c_worker_thread(void* context) {
     I2CWorker* worker = context;
     for(;;) {
@@ -282,7 +590,28 @@ static int32_t i2c_worker_thread(void* context) {
             i2c_worker_do_watch(worker);
             worker->busy = false;
         }
+        if(flags & WORKER_FLAG_PAD) {
+            worker->busy = true;
+            i2c_worker_do_pad_watch(worker);
+            worker->busy = false;
+        }
+        if(flags & WORKER_FLAG_FIX) {
+            worker->busy = true;
+            i2c_worker_do_fix(worker);
+            worker->busy = false;
+        }
+        if(flags & WORKER_FLAG_SELFTEST) {
+            worker->busy = true;
+            i2c_worker_do_selftest(worker);
+            worker->busy = false;
+            i2c_worker_notify(worker, I2CWorkerEventSelftestDone);
+        }
     }
+    // Never leave the bench dark, and never leave a pull hanging on the bus:
+    // whatever the app was doing, the sensor gets its rail and its line back
+    // before this thread stops answering.
+    fix_strap_release();
+    furi_hal_power_enable_external_3_3v();
     return 0;
 }
 
@@ -337,6 +666,34 @@ void i2c_worker_abort_scan(I2CWorker* worker) {
     worker->scan_abort = true;
 }
 
+UartListenOutcome i2c_worker_get_listen(I2CWorker* worker, UartListenResult* out) {
+    furi_mutex_acquire(worker->mutex, FuriWaitForever);
+    UartListenOutcome outcome = (UartListenOutcome)worker->listen_outcome;
+    if(out) *out = worker->listen;
+    furi_mutex_release(worker->mutex);
+    return outcome;
+}
+
+void i2c_worker_selftest_start(I2CWorker* worker) {
+    // Both of those own pins 15 and 16, and the serial handle needs them. The
+    // self-test screen is not reached from either, so this is belt and braces.
+    worker->watch_stop = true;
+    worker->pad_stop = true;
+    furi_thread_flags_set(furi_thread_get_id(worker->thread), WORKER_FLAG_SELFTEST);
+}
+
+I2CSelftestState i2c_worker_get_selftest(I2CWorker* worker, char* detail, size_t detail_size) {
+    furi_mutex_acquire(worker->mutex, FuriWaitForever);
+    I2CSelftestState state = (I2CSelftestState)worker->selftest_state;
+    if(detail && detail_size) snprintf(detail, detail_size, "%s", worker->selftest_detail);
+    furi_mutex_release(worker->mutex);
+    return state;
+}
+
+bool i2c_worker_is_listening(I2CWorker* worker) {
+    return worker->listening;
+}
+
 bool i2c_worker_is_busy(I2CWorker* worker) {
     return worker->busy;
 }
@@ -348,6 +705,45 @@ void i2c_worker_watch_start(I2CWorker* worker) {
 
 void i2c_worker_watch_stop(I2CWorker* worker) {
     worker->watch_stop = true;
+}
+
+void i2c_worker_pad_watch_start(I2CWorker* worker) {
+    worker->pad_stop = false;
+    // Start from nothing rather than from last time's answer. The wire has very
+    // likely been moved to a different pad since, and showing the old level
+    // while the new one settles is showing a measurement of the wrong pin.
+    worker->pad_level = I2CPadUnknown;
+    worker->watch_stop = true; // the bus watcher and the pad meter share pin 15
+    furi_thread_flags_set(furi_thread_get_id(worker->thread), WORKER_FLAG_PAD);
+}
+
+void i2c_worker_pad_watch_stop(I2CWorker* worker) {
+    worker->pad_stop = true;
+}
+
+I2CPadLevel i2c_worker_get_pad(I2CWorker* worker) {
+    return (I2CPadLevel)worker->pad_level;
+}
+
+void i2c_worker_fix_start(I2CWorker* worker, bool want_high) {
+    worker->watch_stop = true; // both of those own pin 15, and the strap needs it
+    worker->pad_stop = true;
+    // Bump the generation before clearing the stop, so a run still unwinding
+    // from the last stop is already out of date by the time the stop it was
+    // watching goes away.
+    worker->fix_gen++;
+    worker->fix_stop = false;
+    worker->fix_want_high = want_high;
+    worker->fix_stage = I2CFixStrapping;
+    furi_thread_flags_set(furi_thread_get_id(worker->thread), WORKER_FLAG_FIX);
+}
+
+void i2c_worker_fix_stop(I2CWorker* worker) {
+    worker->fix_stop = true;
+}
+
+I2CFixStage i2c_worker_get_fix_stage(I2CWorker* worker) {
+    return (I2CFixStage)worker->fix_stage;
 }
 
 void i2c_worker_get_bus(I2CWorker* worker, I2CBusCheck* out) {

--- a/non_catalog_apps/fake_chip_detector/i2c_worker.h
+++ b/non_catalog_apps/fake_chip_detector/i2c_worker.h
@@ -16,6 +16,7 @@
 #define I2C_REG_TIMEOUT_MS   50
 
 #include "chip_db.h"
+#include "uart_listen.h"
 
 typedef struct {
     uint8_t addr; // 7-bit
@@ -28,7 +29,36 @@ typedef enum {
     I2CWorkerEventScanProgress,
     I2CWorkerEventScanDone,
     I2CWorkerEventBusUpdate,
+    I2CWorkerEventPadUpdate,
+    I2CWorkerEventFixUpdate,
+    I2CWorkerEventSelftestDone,
 } I2CWorkerEvent;
+
+// Where a fix run has got to. Every step but the first ends on a measurement,
+// so the screen never says something happened that the app did not see.
+typedef enum {
+    I2CFixIdle, // not running: the pad meter owns the screen
+    I2CFixStrapping, // pulling the pad the way I2C needs it, reading it back
+    I2CFixPadHeld, // the pull lost: the board itself ties this pad
+    I2CFixWantPowerOff, // waiting for the module's pull-ups to disappear
+    I2CFixWantPowerOn, // they went; waiting for them to come back
+    I2CFixWantWire, // strap let go; waiting for the wire back on the bus
+    I2CFixDone, // bus healthy again, worth another sweep
+} I2CFixStage;
+
+// What a single pad is doing, measured with nothing but the internal pulls.
+// Input only: safe to point at a pin whose function nobody knows yet, which is
+// the whole premise of handing this to someone at a parcel counter.
+typedef enum {
+    // Nothing has been measured yet. First, so that a zeroed struct or a meter
+    // that has only just started cannot present itself as a reading. FLOATING
+    // is a result -- and the one that offers the fix on every mode family -- so
+    // it must never double as "no answer yet".
+    I2CPadUnknown,
+    I2CPadFloating, // nothing holds it either way
+    I2CPadHigh, // driven high, or tied to a rail
+    I2CPadLow, // driven low, or tied to ground
+} I2CPadLevel;
 
 // Result of the electrical sanity check performed before a scan.
 typedef enum {
@@ -69,6 +99,44 @@ bool i2c_worker_is_busy(I2CWorker* worker);
 void i2c_worker_watch_start(I2CWorker* worker);
 void i2c_worker_watch_stop(I2CWorker* worker);
 void i2c_worker_get_bus(I2CWorker* worker, I2CBusCheck* out);
+
+// Pad-meter mode: polls pin 15 (SDA) as a bare input so the user can walk that
+// wire onto a mode pin and watch the level. Emits I2CWorkerEventPadUpdate.
+// A level only changes after several agreeing reads: a finger resting on a
+// floating pad drags it around, and a display that flickers is a display
+// nobody trusts.
+void i2c_worker_pad_watch_start(I2CWorker* worker);
+void i2c_worker_pad_watch_stop(I2CWorker* worker);
+I2CPadLevel i2c_worker_get_pad(I2CWorker* worker);
+
+// The fix run: hold the pad at want_high through a restart, then hand the bus
+// back. It straps pin 15 with the internal pull and reads it back, tries once
+// to cut the 3V3 rail itself, and when that does not move the lines it waits
+// for the person to pull the sensor's power wire and put it back -- watching
+// the module's pull-ups vanish and return rather than believing them. Ends by
+// waiting for the wire to come back onto the bus, then emits a final
+// I2CFixDone. Progress arrives as I2CWorkerEventFixUpdate; read the stage with
+// i2c_worker_get_fix_stage. The strap and the rail are released on every path,
+// including the worker shutting down.
+void i2c_worker_fix_start(I2CWorker* worker, bool want_high);
+void i2c_worker_fix_stop(I2CWorker* worker);
+I2CFixStage i2c_worker_get_fix_stage(I2CWorker* worker);
+
+// What the listen that follows an empty sweep established. It runs by itself,
+// with nothing to press: the person this app exists for read the headline as a
+// conclusion and handed a working sensor back, so an extra question they have
+// to think of asking is no question at all. It costs about two seconds and
+// only on a sweep that already failed.
+//
+// UartListenUnavailable on every path where no listening happened, including
+// before the first scan. The zero value claims nothing, which is the answer a
+// caller who forgets to check should get.
+UartListenOutcome i2c_worker_get_listen(I2CWorker* worker, UartListenResult* out);
+
+// True between the end of the sweep and the end of the listen, so the busy
+// screen can say what it is doing rather than sit at 0x77 looking wedged.
+bool i2c_worker_is_listening(I2CWorker* worker);
+
 uint8_t i2c_worker_get_progress(I2CWorker* worker);
 size_t i2c_worker_get_found(I2CWorker* worker, I2CFoundDevice* out, size_t max_count);
 
@@ -97,3 +165,33 @@ bool i2c_worker_write_reg(uint8_t addr7, uint8_t reg, uint8_t value, uint32_t ti
 // convenience on top of these two.
 bool i2c_worker_write_raw(uint8_t addr7, const uint8_t* data, size_t len, uint32_t timeout_ms);
 bool i2c_worker_read_raw(uint8_t addr7, uint8_t* data, size_t len, uint32_t timeout_ms);
+
+/* ---- LPUART loopback self-test ---- */
+
+// How the loopback ended. Never run is the zero value, so a caller who reads
+// this before anything has been tried is told nothing rather than told it
+// passed -- the same rule the listen outcome follows.
+typedef enum {
+    I2CSelftestNeverRun,
+    I2CSelftestPassed,
+    I2CSelftestFailed,
+    // Not a result. Pull-ups were seen on pins 15 and 16, so something is still
+    // wired to them, and the test drives one of those pins. Refusing to run is
+    // a different thing from running and failing, and the user needs to be told
+    // which one happened.
+    I2CSelftestBlocked,
+} I2CSelftestState;
+
+// Big enough for what uart_selftest_loopback writes; it truncates at 40 itself.
+#define I2C_SELFTEST_DETAIL_SIZE 40
+
+// Runs the jumper loopback on the worker thread. It stands the expansion
+// service down and takes the serial handle, which is not work for the thread
+// that is drawing the screen.
+void i2c_worker_selftest_start(I2CWorker* worker);
+
+// detail receives the line the test wrote about itself, verbatim; pass NULL to
+// skip. It is preset to "LPUART unavailable" and only overwritten when the body
+// actually reached the wire, which is what tells "never got a handle" apart
+// from "sent and heard nothing back".
+I2CSelftestState i2c_worker_get_selftest(I2CWorker* worker, char* detail, size_t detail_size);

--- a/non_catalog_apps/fake_chip_detector/live_ak09911.c
+++ b/non_catalog_apps/fake_chip_detector/live_ak09911.c
@@ -1,0 +1,426 @@
+#include "live_ak09911.h"
+
+#include <furi.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+
+// AKM AK09911, a 3-axis electronic compass.
+//
+// Where the numbers come from, and where they stop. The operation modes, the
+// mode-transition rule and the sensitivity are quoted below from the AKM
+// AK09911 ShortDatasheet-E-00 (2014/1), which is the document that could be
+// obtained. It has no register map: the register addresses and the status-bit
+// positions are from issue #38's citation of the full MS1526-E-01 sections
+// 6.3-6.4 and 8.3.3-8.3.11, cross-checked against what a purple AK09911C
+// breakout actually answered on the bench on 8 Sep 2026. Anything below marked
+// "MS1526" is on that footing rather than on a datasheet read here.
+//
+// NOT RUN ON HARDWARE. Every byte of this file is derived from a bench capture
+// somebody else took with a different tool. It compiles and it follows the
+// documented sequence; nobody has yet watched it drive a part.
+
+// MS1526: WIA1 is the AKM company code, WIA2 the device code. Both fixed, and
+// both are read before anything is written -- 0x0C and 0x0D are shared with the
+// QMC5883L, whose whole signature is one register reading 0xFF, so an address
+// that acknowledges proves nothing at all here.
+#define AK_REG_WIA1   0x00
+#define AK_REG_WIA2   0x01
+#define AK_WIA1_AKM   0x48
+#define AK_WIA2_09911 0x05
+
+// MS1526: ST1 at 0x10, then the three little-endian signed 16-bit axes, a dummy
+// byte the datasheet calls TMPS, and ST2 last. All nine are read in one burst
+// because ST2 is what releases the held sample -- stopping short of it leaves
+// the part sitting on the same measurement forever.
+#define AK_REG_ST1   0x10
+#define AK_BURST_LEN 9 // 0x10 through 0x18
+#define AK_ST1_DRDY  0x01 // a fresh measurement is waiting
+#define AK_ST1_DOR   0x02 // a measurement was dropped before this one was read
+#define AK_ST2_HOFL  0x08 // the sensor overflowed; the data is not a reading
+
+// CNTL2, and the five mode bits in it. ShortDatasheet-E-00 figure 6.1:
+// MODE[4:0] = 00000 power-down, 00010 "Continuous measurement mode 1 -- sensor
+// is measured periodically in 10Hz", 10000 "Self-test mode -- sensor is
+// self-tested and the result is output. Transits to Power-down mode
+// automatically", 11111 "Fuse ROM access mode". MS1526 places the register at
+// 0x31 and the fuse-ROM sensitivity bytes at 0x60-0x62.
+#define AK_REG_CNTL2      0x31
+#define AK_MODE_POWERDOWN 0x00
+#define AK_MODE_CONT_10HZ 0x02
+#define AK_MODE_SELFTEST  0x10
+#define AK_MODE_FUSE_ROM  0x1F
+#define AK_REG_ASAX       0x60
+
+// ShortDatasheet-E-00 section 6.3: "When user wants to change operation mode,
+// transit to Power-down mode first and then transit to other modes. After
+// Power-down mode is set, at least 100 us (Twat) is needed before setting
+// another mode." One millisecond is an order of magnitude over that and is the
+// smallest delay this app can express, so every mode change pays it.
+#define AK_MODE_WAIT_MS 1
+
+// A measurement at 10 Hz is 100 ms away at worst, and a self-test is one
+// single-shot conversion. Poll at 20 ms so a fresh sample is never more than
+// that stale, and give up after 500 ms -- five times the slowest expected wait,
+// and short enough that a part which has stopped converting is noticed rather
+// than hung on.
+#define AK_POLL_MS           20
+#define AK_SAMPLE_TIMEOUT_MS 500
+
+// ShortDatasheet-E-00 electrical characteristics: 0.6 uT/LSB typical, after the
+// fuse-ROM sensitivity adjustment. Kept as a float because the heading is the
+// only place it is used and raw counts are what the lines show.
+#define AK_UT_PER_LSB 0.6f
+
+// MS1526 self-test limits, in ADJUSTED counts -- the sensitivity correction
+// has to be applied before comparing, or a part with an unremarkable ASA is
+// failed for it. The internal magnetic source drives Z hard negative, which is
+// why its window is nowhere near the other two.
+#define AK_SELFTEST_XY_LIMIT 30
+#define AK_SELFTEST_Z_MIN    (-400)
+#define AK_SELFTEST_Z_MAX    (-50)
+
+// ponytail: a heuristic, not a specification. On the bench on 8 Sep 2026 the
+// same board rotated together with the Flipper moved 7/21/8 counts on X/Y/Z --
+// that is the noise floor, and it includes whatever the Flipper's own field
+// contributes. Moving the module alone gave 146/812/261. A hundred counts sits
+// five times above the worst of the noise and below the weakest real motion,
+// on two axes so that one drifting channel cannot carry it. Anyone with a
+// magnetically quieter fixture should re-measure both numbers rather than
+// trust these two.
+#define AK_MOVE_COUNTS 100
+#define AK_MOVE_AXES   2
+
+// Two things are proven here, and they are proven separately: the part's own
+// self-test says the magnetic sensor works, and the field it reports afterwards
+// changes when the board is waved. Neither implies the other -- a canned
+// self-test answer would not move, and a noisy channel would not pass the
+// self-test -- which is why both boxes have to fill.
+#define AK_PROOF_STEPS 2
+
+typedef struct {
+    int32_t min;
+    int32_t max;
+} AxisRange;
+
+static void ak_delay(const volatile bool* stop, uint32_t ms) {
+    while(ms && !*stop) {
+        uint32_t chunk = ms > 40 ? 40 : ms;
+        furi_delay_ms(chunk);
+        ms -= chunk;
+    }
+}
+
+static LiveTestIdResult ak_identify(const LiveTestI2c* i2c, uint8_t addr7) {
+    uint8_t wia1 = 0, wia2 = 0;
+    if(!live_test_read_id8(i2c, addr7, AK_REG_WIA1, &wia1))
+        return live_test_id_unreadable(i2c, addr7);
+    if(!live_test_read_id8(i2c, addr7, AK_REG_WIA2, &wia2))
+        return live_test_id_unreadable(i2c, addr7);
+    return (wia1 == AK_WIA1_AKM && wia2 == AK_WIA2_09911) ? LiveTestIdMatch : LiveTestIdMismatch;
+}
+
+// Every mode change goes through power-down and waits Twat, because the
+// datasheet says every mode change goes through power-down. Returns false if
+// either write was not acknowledged, and the caller must then treat the part as
+// still configured -- the first write may well have landed.
+static bool
+    ak_set_mode(const LiveTestI2c* i2c, uint8_t addr7, const volatile bool* stop, uint8_t mode) {
+    if(!i2c->write_reg(addr7, AK_REG_CNTL2, AK_MODE_POWERDOWN, LIVE_TEST_TIMEOUT_MS)) return false;
+    ak_delay(stop, AK_MODE_WAIT_MS);
+    if(mode == AK_MODE_POWERDOWN) return true;
+    if(!i2c->write_reg(addr7, AK_REG_CNTL2, mode, LIVE_TEST_TIMEOUT_MS)) return false;
+    ak_delay(stop, AK_MODE_WAIT_MS);
+    return true;
+}
+
+// Three outcomes, because they call for three different responses and folding
+// them together is how a strong magnet gets reported as a broken sensor.
+typedef enum {
+    AkSampleOk,
+    AkSampleOverflow, // the sensor saturated: discard it, but nothing is wrong
+    AkSampleFailed, // the bus failed, or nothing became ready in time
+} AkSampleResult;
+
+// One measurement, start to finish: wait for DRDY, then read all nine bytes so
+// that ST2 releases the sample. Stopping short of ST2 leaves the part sitting
+// on the same measurement forever, which reads as a working sensor with a
+// beautifully stable field.
+//
+// An overflowed sample is not a small reading, it is not a reading at all, so
+// its bytes are never returned -- printing them would be printing a number the
+// part did not stand behind.
+//
+// `dropped` counts DOR separately again. A measurement going unread is not an
+// error on the bus and not a fault in the part; at 10 Hz it means this loop was
+// busy, and it is worth showing without being counted as a failure.
+static AkSampleResult ak_read_sample(
+    const LiveTestI2c* i2c,
+    uint8_t addr7,
+    const volatile bool* stop,
+    int32_t out[3],
+    uint16_t* dropped) {
+    for(uint32_t waited = 0; waited < AK_SAMPLE_TIMEOUT_MS && !*stop; waited += AK_POLL_MS) {
+        uint8_t buf[AK_BURST_LEN] = {0};
+        if(!i2c->read_mem(addr7, AK_REG_ST1, buf, sizeof(buf), LIVE_TEST_TIMEOUT_MS))
+            return AkSampleFailed;
+
+        if(!(buf[0] & AK_ST1_DRDY)) {
+            ak_delay(stop, AK_POLL_MS);
+            continue;
+        }
+        if(buf[0] & AK_ST1_DOR) (*dropped)++;
+        if(buf[8] & AK_ST2_HOFL) return AkSampleOverflow;
+
+        for(uint8_t axis = 0; axis < 3; axis++) {
+            // Little-endian, low byte first. The MPU family is the other way
+            // round, and getting this backwards produces numbers that look
+            // entirely plausible.
+            out[axis] =
+                (int16_t)((uint16_t)buf[1 + axis * 2] | ((uint16_t)buf[2 + axis * 2] << 8));
+        }
+        return AkSampleOk;
+    }
+    return AkSampleFailed;
+}
+
+// Hadj = H * (1 + ASA/128), from MS1526. This is the factory sensitivity
+// correction and nothing else: it is not hard- or soft-iron calibration, and a
+// part whose fuse ROM could not be read is measured uncorrected rather than
+// measured wrong.
+static int32_t ak_adjust(int32_t raw, uint8_t asa) {
+    if(!asa) return raw;
+    return raw * (128 + (int32_t)asa) / 128;
+}
+
+static void ak_run(const LiveTestEnv* env) {
+    const uint8_t addr7 = env->addr7;
+    const volatile bool* stop = env->stop;
+    const LiveTestI2c* i2c = env->i2c;
+    const LiveTestPublish publish = env->publish;
+    void* const ctx = env->ctx;
+
+    while(!*stop) {
+        LiveTestState st;
+        memset(&st, 0, sizeof(st));
+        st.phase = LiveTestPhaseStarting;
+        snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Reading the compass ID");
+        publish(ctx, &st);
+
+        const LiveTestIdResult id_seen = ak_identify(i2c, addr7);
+        if(id_seen != LiveTestIdMatch) {
+            memset(&st, 0, sizeof(st));
+            // Worded for both halves of what got us here: an ID that read back
+            // wrong, and an ID that could not be read at all. 0x0D also holds
+            // the QMC5883L, so the wrong module really is the likely case.
+            st.phase = id_seen == LiveTestIdMismatch ? LiveTestPhaseWrongChip : LiveTestPhaseLost;
+            if(id_seen == LiveTestIdMismatch) {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "0x%02X answers, but not", addr7);
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "the way an AK09911 does.");
+            } else {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It replied, then stopped.");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Check RST, 3V3 and wires.");
+            }
+            publish(ctx, &st);
+            ak_delay(
+                stop,
+                id_seen == LiveTestIdMismatch ? LIVE_TEST_WRONG_CHIP_RETRY_MS :
+                                                LIVE_TEST_RETRY_MS);
+            continue;
+        }
+
+        // From here on the part has been identified and every path below writes
+        // CNTL2, so there is unconditionally something to put back -- including
+        // when a write was not acknowledged, because one that was not
+        // acknowledged may still have landed.
+
+        // --- Factory sensitivity ---------------------------------------
+        // Fuse ROM access, three bytes, straight back to power-down. A part
+        // that will not give them up is measured without the correction and
+        // says so; the issue this test came from recorded a board whose CNTL2
+        // read back 0x00 while in fuse-ROM mode, so the readback is not
+        // treated as evidence either way.
+        uint8_t asa[3] = {0};
+        bool have_asa = false;
+        if(ak_set_mode(i2c, addr7, stop, AK_MODE_FUSE_ROM)) {
+            have_asa = i2c->read_mem(addr7, AK_REG_ASAX, asa, sizeof(asa), LIVE_TEST_TIMEOUT_MS);
+            // 0x00 and 0xFF are what an unprogrammed or absent fuse ROM reads
+            // as, and either would scale every later number by nonsense.
+            for(uint8_t i = 0; i < 3; i++) {
+                if(asa[i] == 0x00 || asa[i] == 0xFF) have_asa = false;
+            }
+        }
+        ak_set_mode(i2c, addr7, stop, AK_MODE_POWERDOWN);
+        if(!have_asa) memset(asa, 0, sizeof(asa));
+
+        // --- Self-test --------------------------------------------------
+        memset(&st, 0, sizeof(st));
+        st.phase = LiveTestPhaseStarting;
+        st.progress_max = AK_PROOF_STEPS;
+        snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Running the self-test");
+        snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Hold it still.");
+        publish(ctx, &st);
+
+        // The sequence issue #38 asks for is "enter power-down, clear any
+        // previous ready sample through ST2, request 31=10". The middle step
+        // is not decoration: DRDY clears on an ST2 read and not on a mode
+        // write, so a part that an earlier run left in continuous mode still
+        // has an earth-field measurement waiting -- and the first poll after
+        // the self-test write would return that, unmeasured by the self-test
+        // coil, as the self-test result. The read is discarded and its failure
+        // ignored: there may be nothing pending, and whether the bus works is
+        // about to be established by the self-test itself.
+        uint8_t stale[AK_BURST_LEN] = {0};
+        i2c->read_mem(addr7, AK_REG_ST1, stale, sizeof(stale), LIVE_TEST_TIMEOUT_MS);
+
+        int32_t self[3] = {0};
+        uint16_t dropped = 0;
+        bool self_ok = false;
+        bool self_ran = ak_set_mode(i2c, addr7, stop, AK_MODE_SELFTEST) &&
+                        ak_read_sample(i2c, addr7, stop, self, &dropped) == AkSampleOk;
+        if(self_ran) {
+            for(uint8_t axis = 0; axis < 3; axis++) {
+                self[axis] = ak_adjust(self[axis], asa[axis]);
+            }
+            self_ok = self[0] >= -AK_SELFTEST_XY_LIMIT && self[0] <= AK_SELFTEST_XY_LIMIT &&
+                      self[1] >= -AK_SELFTEST_XY_LIMIT && self[1] <= AK_SELFTEST_XY_LIMIT &&
+                      self[2] >= AK_SELFTEST_Z_MIN && self[2] <= AK_SELFTEST_Z_MAX;
+        }
+
+        // --- Continuous measurement ------------------------------------
+        bool measuring = ak_set_mode(i2c, addr7, stop, AK_MODE_CONT_10HZ);
+
+        AxisRange range[3];
+        for(uint8_t axis = 0; axis < 3; axis++) {
+            range[axis] = (AxisRange){.min = INT32_MAX, .max = INT32_MIN};
+        }
+        uint32_t started = furi_get_tick();
+        uint32_t samples = 0;
+        uint16_t overflows = 0;
+        uint8_t errors = 0;
+        bool passed = false;
+
+        while(measuring && !passed && !*stop && errors < 3) {
+            int32_t raw[3] = {0};
+            const AkSampleResult got = ak_read_sample(i2c, addr7, stop, raw, &dropped);
+            if(got == AkSampleOverflow) {
+                // Saturated. Somebody is holding a magnet against it, which is
+                // a fine thing to be doing and not a reason to give up on the
+                // part -- so this does not count towards the error budget and
+                // does not go into the ranges either.
+                overflows++;
+                continue;
+            }
+            if(got != AkSampleOk) {
+                errors++;
+                continue;
+            }
+            errors = 0;
+            samples++;
+
+            uint8_t moved = 0;
+            for(uint8_t axis = 0; axis < 3; axis++) {
+                if(raw[axis] < range[axis].min) range[axis].min = raw[axis];
+                if(raw[axis] > range[axis].max) range[axis].max = raw[axis];
+                if(range[axis].max - range[axis].min >= AK_MOVE_COUNTS) moved++;
+            }
+            passed = self_ok && moved >= AK_MOVE_AXES;
+            if(passed) break; // publish it after the part is parked, not before
+
+            const float field =
+                AK_UT_PER_LSB * sqrtf(
+                                    (float)ak_adjust(raw[0], asa[0]) * ak_adjust(raw[0], asa[0]) +
+                                    (float)ak_adjust(raw[1], asa[1]) * ak_adjust(raw[1], asa[1]) +
+                                    (float)ak_adjust(raw[2], asa[2]) * ak_adjust(raw[2], asa[2]));
+
+            memset(&st, 0, sizeof(st));
+            st.phase = LiveTestPhaseRunning;
+            st.value = field;
+            st.progress = self_ok ? 1 : 0;
+            st.progress_max = AK_PROOF_STEPS;
+            snprintf(st.heading, sizeof(st.heading), "%u", (unsigned)field);
+            snprintf(st.unit, sizeof(st.unit), "uT");
+            snprintf(
+                st.lines[0],
+                LIVE_TEST_LINE_LEN,
+                "%ld %ld %ld",
+                (long)raw[0],
+                (long)raw[1],
+                (long)raw[2]);
+            snprintf(
+                st.lines[1],
+                LIVE_TEST_LINE_LEN,
+                self_ran ? (self_ok ? "Self-test OK    %lus" : "Self-test FAIL  %lus") :
+                           "No self-test    %lus",
+                (unsigned long)((furi_get_tick() - started) / furi_ms_to_ticks(1000)));
+            if(overflows) {
+                // Saying "wave it" at somebody whose sensor is saturating is
+                // advice pointing the wrong way: the field is already too
+                // strong to measure and the magnet needs backing off, not
+                // moving.
+                snprintf(
+                    st.lines[2], LIVE_TEST_LINE_LEN, "Field too strong x%u", (unsigned)overflows);
+            } else {
+                snprintf(
+                    st.lines[2],
+                    LIVE_TEST_LINE_LEN,
+                    "%lu reads, %u/%u axes",
+                    (unsigned long)samples,
+                    moved,
+                    AK_MOVE_AXES);
+            }
+            publish(ctx, &st);
+        }
+
+        // --- Park it ----------------------------------------------------
+        // Before anything is published, so that the chime the app plays on a
+        // pass lands after the last measurement rather than during one: this
+        // is a magnetometer, and the speaker sits next to it.
+        const bool parked = ak_set_mode(i2c, addr7, stop, AK_MODE_POWERDOWN);
+
+        if(*stop) break;
+
+        memset(&st, 0, sizeof(st));
+        st.progress_max = AK_PROOF_STEPS;
+        if(passed) {
+            st.phase = LiveTestPhasePassed;
+            st.progress = AK_PROOF_STEPS;
+            snprintf(st.heading, sizeof(st.heading), "%lu", (unsigned long)samples);
+            snprintf(st.unit, sizeof(st.unit), "reads");
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Self-test passed, and");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "the field followed you.");
+            snprintf(
+                st.lines[2],
+                LIVE_TEST_LINE_LEN,
+                parked ? "%u dropped" : "%u dropped, not parked",
+                (unsigned)dropped);
+            publish(ctx, &st);
+            // The screen belongs to the user now. Nothing is being measured
+            // and nothing is configured, so this is a plain wait for Back.
+            while(!*stop)
+                ak_delay(stop, AK_POLL_MS);
+            break;
+        }
+
+        st.phase = LiveTestPhaseLost;
+        st.progress = self_ok ? 1 : 0;
+        if(!measuring) {
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It will not start");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "measuring. Check 3V3.");
+        } else {
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It stopped answering.");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Check RST, 3V3 and wires.");
+        }
+        publish(ctx, &st);
+        ak_delay(stop, LIVE_TEST_RETRY_MS);
+    }
+}
+
+const LiveTest live_test_ak09911 = {
+    .chip = "AK09911",
+    .title = "AK09911 test",
+    .offer = "Wave it through a field",
+    .addrs = {0x0C, 0x0D},
+    .run = ak_run,
+    .draw = NULL,
+};

--- a/non_catalog_apps/fake_chip_detector/live_ak09911.c
+++ b/non_catalog_apps/fake_chip_detector/live_ak09911.c
@@ -80,15 +80,26 @@
 #define AK_SELFTEST_Z_MIN    (-400)
 #define AK_SELFTEST_Z_MAX    (-50)
 
-// ponytail: a heuristic, not a specification. On the bench on 8 Sep 2026 the
-// same board rotated together with the Flipper moved 7/21/8 counts on X/Y/Z --
-// that is the noise floor, and it includes whatever the Flipper's own field
-// contributes. Moving the module alone gave 146/812/261. A hundred counts sits
-// five times above the worst of the noise and below the weakest real motion,
-// on two axes so that one drifting channel cannot carry it. Anyone with a
-// magnetically quieter fixture should re-measure both numbers rather than
-// trust these two.
-#define AK_MOVE_COUNTS 100
+// ponytail: a heuristic, not a specification, and the first version of it was
+// wrong in a way only hardware could show. It was set to 100 from a bench
+// capture where waving the module gave 146/812/261 counts -- but 812 counts is
+// 487 uT, ten times the earth's field, so something magnetic was sitting next
+// to the sensor during that capture. Against the earth alone the whole vector
+// is only about 50 raw counts here, and one axis cannot swing further than
+// twice that even when turned exactly end over end. A hundred counts on two
+// axes was therefore above the physical maximum: the test could not pass, and
+// on 9 Sep 2026 somebody turned the board for two and a half minutes proving
+// it -- 1545 reads, swings plateaued at 38/47/26 and the counter never left
+// 0/2.
+//
+// Thirty is set from that same session: stationary noise was 4/5/7 counts, so
+// it sits four to seven times above the noise, and ordinary handling reached
+// 38 and 47 on two axes. The weakest place on earth has a field about half of
+// this one's, where 30 still needs most of a full inversion -- if it proves
+// unreachable somewhere, re-measure both numbers there rather than trusting
+// these. Measure the still board first: the noise floor is the half that says
+// whether a threshold means anything.
+#define AK_MOVE_COUNTS 30
 #define AK_MOVE_AXES   2
 
 // Two things are proven here, and they are proven separately: the part's own
@@ -307,8 +318,18 @@ static void ak_run(const LiveTestEnv* env) {
                 // Saturated. Somebody is holding a magnet against it, which is
                 // a fine thing to be doing and not a reason to give up on the
                 // part -- so this does not count towards the error budget and
-                // does not go into the ranges either.
+                // does not go into the ranges either. It does have to reach
+                // the screen, though: HOFL stays set for as long as the magnet
+                // is there, so skipping the publish froze the display on the
+                // last good frame and the advice to back off never appeared.
                 overflows++;
+                memset(&st, 0, sizeof(st));
+                st.phase = LiveTestPhaseRunning;
+                st.progress = self_ok ? 1 : 0;
+                st.progress_max = AK_PROOF_STEPS;
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Too strong - back it off");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Saturated x%u", (unsigned)overflows);
+                publish(ctx, &st);
                 continue;
             }
             if(got != AkSampleOk) {
@@ -340,35 +361,27 @@ static void ak_run(const LiveTestEnv* env) {
             st.progress_max = AK_PROOF_STEPS;
             snprintf(st.heading, sizeof(st.heading), "%u", (unsigned)field);
             snprintf(st.unit, sizeof(st.unit), "uT");
+            // Two lines, not three. With a big heading and the progress
+            // boxes the generic screen has room for exactly two: it starts at
+            // y=46, steps 9 and stops at 55, so a third is composed and then
+            // silently dropped. That is how this test shipped -- the progress
+            // count and the saturation warning were both written to lines[2]
+            // and neither was ever drawn, which left the screen showing raw
+            // counts and no hint that the user was meant to do anything.
+            //
+            // So line 0 is the instruction, carrying its own feedback the way
+            // the ADXL345 test's "Gravity on X - tip it" does, and line 1 is
+            // the evidence. Raw XYZ came out: the heading is the same field in
+            // uT and it moves, and "1/2 axes" says what the triple was there
+            // to say in the form the user can act on.
             snprintf(
-                st.lines[0],
-                LIVE_TEST_LINE_LEN,
-                "%ld %ld %ld",
-                (long)raw[0],
-                (long)raw[1],
-                (long)raw[2]);
+                st.lines[0], LIVE_TEST_LINE_LEN, "Turn it over - %u/%u axes", moved, AK_MOVE_AXES);
             snprintf(
                 st.lines[1],
                 LIVE_TEST_LINE_LEN,
                 self_ran ? (self_ok ? "Self-test OK    %lus" : "Self-test FAIL  %lus") :
                            "No self-test    %lus",
                 (unsigned long)((furi_get_tick() - started) / furi_ms_to_ticks(1000)));
-            if(overflows) {
-                // Saying "wave it" at somebody whose sensor is saturating is
-                // advice pointing the wrong way: the field is already too
-                // strong to measure and the magnet needs backing off, not
-                // moving.
-                snprintf(
-                    st.lines[2], LIVE_TEST_LINE_LEN, "Field too strong x%u", (unsigned)overflows);
-            } else {
-                snprintf(
-                    st.lines[2],
-                    LIVE_TEST_LINE_LEN,
-                    "%lu reads, %u/%u axes",
-                    (unsigned long)samples,
-                    moved,
-                    AK_MOVE_AXES);
-            }
             publish(ctx, &st);
         }
 
@@ -387,13 +400,17 @@ static void ak_run(const LiveTestEnv* env) {
             st.progress = AK_PROOF_STEPS;
             snprintf(st.heading, sizeof(st.heading), "%lu", (unsigned long)samples);
             snprintf(st.unit, sizeof(st.unit), "reads");
-            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Self-test passed, and");
-            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "the field followed you.");
-            snprintf(
-                st.lines[2],
-                LIVE_TEST_LINE_LEN,
-                parked ? "%u dropped" : "%u dropped, not parked",
-                (unsigned)dropped);
+            // Same two-line budget as the running screen, and "not parked"
+            // is the half worth keeping: a part left in continuous mode goes
+            // on drawing current and the next run inherits it. The dropped
+            // count was diagnostic and went with the third line.
+            if(parked) {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Self-test passed, and");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "the field followed you.");
+            } else {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Passed, but the part was");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "left configured. Repower.");
+            }
             publish(ctx, &st);
             // The screen belongs to the user now. Nothing is being measured
             // and nothing is configured, so this is a plain wait for Back.

--- a/non_catalog_apps/fake_chip_detector/live_ak09911.h
+++ b/non_catalog_apps/fake_chip_detector/live_ak09911.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "live_test.h"
+
+extern const LiveTest live_test_ak09911;

--- a/non_catalog_apps/fake_chip_detector/live_qmc5883p.c
+++ b/non_catalog_apps/fake_chip_detector/live_qmc5883p.c
@@ -1,0 +1,479 @@
+#include "live_qmc5883p.h"
+
+#include <furi.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+
+// QST QMC5883P, a 3-axis magnetometer. Every constant below is quoted from the
+// QMC5883P datasheet, QST document 13-52-19 Rev. C, with the section and page
+// named at each one. That document was obtained in full, which is the
+// difference between this file and live_ak09911.c next to it.
+//
+// The part is worth a test for a reason that has nothing to do with its
+// registers. GY-271 is the module name the Honeywell HMC5883L made famous, and
+// a GY-271 bought today usually has a QST die on it -- an L or, increasingly, a
+// P. The three are not register-compatible with each other. So the number
+// silkscreened on the board says almost nothing, the chip ID says which die is
+// there, and this test says whether that die does the job. On 9 Sep 2026 a blue
+// GY-271 on the bench answered at 0x2C and read 0x80 at register 0x00, which is
+// what prompted the file.
+//
+// Run on that board the same day, and it passed: the coil fired, the field
+// followed the board through the earth's, 1036 reads. A second entry into the
+// same screen did not, and the two faults it exposed are fixed above -- the
+// self-test no longer waits for a DRDY the part has stopped producing, and the
+// measurement configuration is established from a soft reset instead of
+// written on top of whatever the previous run left. That fix has not itself
+// been back on silicon. See BACKLOG.md.
+
+// Rev. C section 9.2.1, page 14: "Register 00H stores the chip ID. The default
+// value is 80H." One byte, and the only fixed thing in the map -- which makes
+// it a weak signature on its own, so it is read twice through
+// live_test_read_id8 and nothing is written until it agrees with itself.
+#define QMC_REG_CHIPID 0x00
+#define QMC_CHIPID     0x80
+
+// Rev. C Table 14 and Table 15, page 14: 01H..06H are X/Y/Z as LSB then MSB,
+// "16-bit data width in 2's complement". Read as one six-byte burst.
+#define QMC_REG_XOUT_LSB 0x01
+#define QMC_DATA_LEN     6
+
+// Rev. C section 9.2.2 and Table 16, page 14: status register 09H, bit 0 DRDY
+// "0: no new data, 1: new data is ready", bit 1 OVFL "set high when either axis
+// code output exceeds the range of [-30000,30000] LSB". Both are "reset to 0
+// after this bit is read", so one read of 09H consumes both flags and the data
+// registers must be read before asking again.
+#define QMC_REG_STATUS 0x09
+#define QMC_ST_DRDY    0x01
+#define QMC_ST_OVFL    0x02
+
+// Rev. C Table 17 and Table 18, page 15 and 16. Control register 1 at 0AH holds
+// OSR2<7:6>, OSR1<5:4>, ODR<3:2> and MODE<1:0>; control register 2 at 0BH holds
+// SOFT_RST<7>, SELF_TEST<6>, RNG<3:2> and SET/RESET MODE<1:0>.
+#define QMC_REG_CTRL1 0x0A
+#define QMC_REG_CTRL2 0x0B
+
+// The datasheet's own worked examples, quoted whole rather than assembled from
+// bit fields -- a byte that the manufacturer has written down and a byte that
+// happens to have the right bits in it are not the same kind of evidence.
+//
+// Rev. C section 7.2, page 11, "Continuous Mode Setup Example":
+//   Write Register 29H by 0x06 (Define the sign for X Y and Z axis)
+//   Write Register 0BH by 0x08 (Define Set/Reset mode, with Set/Reset On,
+//                               Field Range 8Guass)
+//   Write Register 0AH by 0xC3 (set continuous mode)
+#define QMC_REG_SIGN       0x29
+#define QMC_SIGN_VALUE     0x06
+#define QMC_CTRL2_RUN      0x08
+#define QMC_CTRL1_CONT     0xC3
+// Rev. C section 7.3, page 11, "Self-test Example": continuous mode is entered
+// with 0x03 and no 0BH write at all, so the range stays at its reset value.
+#define QMC_CTRL1_SELFRUN  0x03
+// Rev. C section 7.3: "Write Register 0BH by 0x40 (enter self-test function)".
+// Table 18: SELF_TEST is "1: self_test enable, auto clear after the data is
+// updated", and section 6.2.3 adds that the self-test "can only be enabled in
+// Continuous Mode and enters in Suspend Mode after the data is updated".
+#define QMC_CTRL2_SELFTEST 0x40
+// Rev. C section 7.6, page 11, "Soft Reset Example: Write Register 0BH by
+// 0x80", and Table 18: "1: Soft reset, restore default value of all registers".
+// One write undoes the sign register, both control registers and the mode --
+// which is why parking this part needs no bookkeeping about what was changed.
+#define QMC_CTRL2_SOFTRST  0x80
+// Rev. C section 7.4: "Suspend Mode Example: Write Register 0AH by 0x00".
+#define QMC_CTRL1_SUSPEND  0x00
+
+// Rev. C section 7.3: "Waiting 5 millisecond until measurement ends" between
+// arming the self-test and reading the second sample. Ten is double it, and the
+// only cost of being generous here is ten milliseconds once per run.
+#define QMC_SELFTEST_MS 10
+
+// The datasheet gives no settling time for the soft reset anywhere. Ten is the
+// same generous round number for the same reason -- it is paid twice per run.
+#define QMC_RESET_SETTLE_MS 10
+
+// Rev. C Table 2, page 8: sensitivity is 1000 LSB/G at the +/-30 G range and
+// 3750 LSB/G at +/-8 G. The self-test runs at the reset range because the
+// datasheet's example does; the measurement phase runs at +/-8 G because its
+// example does, and because four times the counts per gauss is four times the
+// evidence when the whole signal is the earth.
+#define QMC_LSB_PER_G_RESET 1000
+#define QMC_LSB_PER_G_RUN   3750
+
+// One gauss is a hundred microtesla, and microtesla is what the heading shows:
+// the earth reads about 50 of them, which is a number somebody can sanity-check
+// against the AK09911 test on the same bench.
+#define QMC_UT_PER_G 100.0f
+
+// Rev. C Table 2, page 8, "Field Resolution, standard deviation": 2 mGauss on
+// X and Y, 3 mGauss on Z. At the reset range's 1000 LSB/G that is 2, 2 and 3
+// counts of noise, so these are three sigma.
+//
+// This is a floor, not the specification. Section 9.2.3 says the self-test
+// "generat[es] a difference in the 3 axis' value" and that the "user should
+// record the value before and after the self-test and compare with threshold
+// value" -- and then publishes no threshold, anywhere in the document. So this
+// test cannot check the size of the deflection against what QST expects, and it
+// does not pretend to: it checks that a deflection happened at all, on every
+// axis, by a margin the part's own published noise cannot produce. A canned
+// register or a die that ignores bit 6 of 0BH gives zero. A working part gives
+// far more than nine counts, and if some part somewhere does not, the honest
+// fix is to obtain the threshold from QST rather than to lower these.
+#define QMC_SELFTEST_MIN_XY 6
+#define QMC_SELFTEST_MIN_Z  9
+
+// ponytail: derived from the datasheet rather than measured, which is exactly
+// the footing that made the AK09911 threshold wrong the first time -- so here
+// is the arithmetic, to be checked against a still part before it is trusted.
+//
+// The earth's field is 0.25 to 0.65 gauss depending on where you stand. At the
+// +/-8 G range's 3750 LSB/G that is 937 counts at the weakest place on earth,
+// and turning a board exactly end over end swings one axis by twice the
+// component along it -- so 1875 counts is the worst-case ceiling, not the
+// expectation. Three hundred is sixteen per cent of that ceiling, and forty
+// times the 7.5 counts of noise the same table implies at this range.
+//
+// The lesson from live_ak09911.c applies here and has not been paid yet:
+// measure the still board first. A threshold means nothing until the noise
+// floor under it is known, and this one has never been compared to one.
+#define QMC_MOVE_COUNTS 300
+#define QMC_MOVE_AXES   2
+
+// Two independent things, and neither implies the other: the part's own coil
+// deflects all three channels, and the field those channels report afterwards
+// follows the board through the earth's. A canned answer fails the second, a
+// dead channel fails the first.
+#define QMC_PROOF_STEPS 2
+
+// Continuous mode "runs all the time without sleep time" (section 6.2.3), so a
+// sample is never far away. Poll at 20 ms and give up after 500, which is
+// twenty-five polls -- long enough that a slow part is waited for, short enough
+// that a stopped one is noticed.
+#define QMC_POLL_MS           20
+#define QMC_SAMPLE_TIMEOUT_MS 500
+
+typedef struct {
+    int32_t min;
+    int32_t max;
+} QmcAxisRange;
+
+typedef enum {
+    QmcSampleOk,
+    QmcSampleOverflow, // past +/-30000 LSB: not a small reading, not a reading
+    QmcSampleFailed, // the bus failed, or nothing became ready in time
+} QmcSampleResult;
+
+static void qmc_delay(const volatile bool* stop, uint32_t ms) {
+    while(ms && !*stop) {
+        uint32_t chunk = ms > 40 ? 40 : ms;
+        furi_delay_ms(chunk);
+        ms -= chunk;
+    }
+}
+
+// Section 7.6's soft reset, used as the first step of every configuration here
+// rather than only as the last step of the run. Table 18: it restores "default
+// value of all registers" and "can be invoked at any time of any mode", and the
+// default mode is Suspend -- which is also what section 9.2.3 asks for when it
+// says "Suspend Mode should be added in the middle of mode shifting between
+// Continuous Mode, Single Mode and Normal Mode". One write therefore does both
+// jobs: it clears whatever the previous pass left in 0AH, 0BH and 29H, and it
+// puts the part in the mode the next write is allowed to leave.
+//
+// This is not tidiness. On silicon the first run of this test passed and the
+// second did not, because the second began on a part still carrying the first
+// run's state, and every number after that was measured through a
+// configuration nobody had established.
+static bool qmc_reset(const LiveTestI2c* i2c, uint8_t addr7, const volatile bool* stop) {
+    if(!i2c->write_reg(addr7, QMC_REG_CTRL2, QMC_CTRL2_SOFTRST, LIVE_TEST_TIMEOUT_MS))
+        return false;
+    qmc_delay(stop, QMC_RESET_SETTLE_MS);
+    return true;
+}
+
+static LiveTestIdResult qmc_identify(const LiveTestI2c* i2c, uint8_t addr7) {
+    uint8_t id = 0;
+    if(!live_test_read_id8(i2c, addr7, QMC_REG_CHIPID, &id))
+        return live_test_id_unreadable(i2c, addr7);
+    return id == QMC_CHIPID ? LiveTestIdMatch : LiveTestIdMismatch;
+}
+
+// The six data bytes, assembled. Table 15 has them LSB register first then MSB
+// for each axis, "16-bit data width in 2's complement". Getting that backwards
+// produces numbers that look entirely plausible and are not.
+static bool qmc_read_data(const LiveTestI2c* i2c, uint8_t addr7, int32_t out[3]) {
+    uint8_t buf[QMC_DATA_LEN] = {0};
+    if(!i2c->read_mem(addr7, QMC_REG_XOUT_LSB, buf, sizeof(buf), LIVE_TEST_TIMEOUT_MS))
+        return false;
+    for(uint8_t axis = 0; axis < 3; axis++) {
+        out[axis] = (int16_t)((uint16_t)buf[axis * 2] | ((uint16_t)buf[axis * 2 + 1] << 8));
+    }
+    return true;
+}
+
+// One measurement: wait for DRDY in 09H, then read the six data bytes. The
+// status read is what clears both flags, so it happens once per attempt and its
+// result is carried out rather than asked for again.
+//
+// An overflowed sample is reported as such and its bytes are never returned.
+// Printing them would be printing a number the part did not stand behind, and
+// past 30000 LSB the axis has run out of range rather than measured anything.
+static QmcSampleResult qmc_read_sample(
+    const LiveTestI2c* i2c,
+    uint8_t addr7,
+    const volatile bool* stop,
+    int32_t out[3]) {
+    for(uint32_t waited = 0; waited < QMC_SAMPLE_TIMEOUT_MS && !*stop; waited += QMC_POLL_MS) {
+        uint8_t status = 0;
+        if(!i2c->read_reg(addr7, QMC_REG_STATUS, &status, LIVE_TEST_TIMEOUT_MS))
+            return QmcSampleFailed;
+
+        if(!(status & QMC_ST_DRDY)) {
+            qmc_delay(stop, QMC_POLL_MS);
+            continue;
+        }
+        if(status & QMC_ST_OVFL) return QmcSampleOverflow;
+
+        if(!qmc_read_data(i2c, addr7, out)) return QmcSampleFailed;
+        return QmcSampleOk;
+    }
+    return QmcSampleFailed;
+}
+
+// The datasheet's section 7.3 in order, with the two reads it asks for. The
+// deltas it defines are (x1-x2), (y2-y1) and (z2-z1) -- written with different
+// signs per axis because the internal coil pushes X one way and Y and Z the
+// other. Only the size of each is checked here; see QMC_SELFTEST_MIN_XY for why
+// the direction is not.
+static bool qmc_self_test(
+    const LiveTestI2c* i2c,
+    uint8_t addr7,
+    const volatile bool* stop,
+    int32_t delta[3]) {
+    if(!qmc_reset(i2c, addr7, stop)) return false;
+    if(!i2c->write_reg(addr7, QMC_REG_SIGN, QMC_SIGN_VALUE, LIVE_TEST_TIMEOUT_MS)) return false;
+    if(!i2c->write_reg(addr7, QMC_REG_CTRL1, QMC_CTRL1_SELFRUN, LIVE_TEST_TIMEOUT_MS))
+        return false;
+
+    int32_t before[3] = {0};
+    if(qmc_read_sample(i2c, addr7, stop, before) != QmcSampleOk) return false;
+
+    if(!i2c->write_reg(addr7, QMC_REG_CTRL2, QMC_CTRL2_SELFTEST, LIVE_TEST_TIMEOUT_MS))
+        return false;
+    qmc_delay(stop, QMC_SELFTEST_MS);
+
+    // Section 7.3 waits and then reads, with no second look at 09H: "Waiting 5
+    // millisecond until measurement ends / Read data Register 01H ~ 06H".
+    // Section 6.2.3 says why that is not an oversight -- the self-test "can
+    // only be enabled in Continuous Mode and enters in Suspend Mode after the
+    // data is updated", so a part that has finished is a part that has stopped,
+    // and DRDY is a flag on a sample that is not coming. Waiting for it here is
+    // what made the second run on silicon report "No self-test" from a part
+    // that had just done one.
+    int32_t after[3] = {0};
+    if(!qmc_read_data(i2c, addr7, after)) return false;
+
+    delta[0] = before[0] - after[0];
+    delta[1] = after[1] - before[1];
+    delta[2] = after[2] - before[2];
+    return true;
+}
+
+static bool qmc_self_test_passed(const int32_t delta[3]) {
+    const int32_t x = delta[0] < 0 ? -delta[0] : delta[0];
+    const int32_t y = delta[1] < 0 ? -delta[1] : delta[1];
+    const int32_t z = delta[2] < 0 ? -delta[2] : delta[2];
+    return x >= QMC_SELFTEST_MIN_XY && y >= QMC_SELFTEST_MIN_XY && z >= QMC_SELFTEST_MIN_Z;
+}
+
+static void qmc_run(const LiveTestEnv* env) {
+    const uint8_t addr7 = env->addr7;
+    const volatile bool* stop = env->stop;
+    const LiveTestI2c* i2c = env->i2c;
+    const LiveTestPublish publish = env->publish;
+    void* const ctx = env->ctx;
+
+    while(!*stop) {
+        LiveTestState st;
+        memset(&st, 0, sizeof(st));
+        st.phase = LiveTestPhaseStarting;
+        snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Reading the chip ID");
+        publish(ctx, &st);
+
+        const LiveTestIdResult id_seen = qmc_identify(i2c, addr7);
+        if(id_seen != LiveTestIdMatch) {
+            memset(&st, 0, sizeof(st));
+            st.phase = id_seen == LiveTestIdMismatch ? LiveTestPhaseWrongChip : LiveTestPhaseLost;
+            if(id_seen == LiveTestIdMismatch) {
+                // The likely case by some distance. A GY-271 board can carry an
+                // HMC5883L, a QMC5883L or this, and only this one sits at 0x2C.
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "0x%02X answers, but not", addr7);
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "the way a QMC5883P does.");
+            } else {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It replied, then stopped.");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Check 3V3 and the wires.");
+            }
+            publish(ctx, &st);
+            qmc_delay(
+                stop,
+                id_seen == LiveTestIdMismatch ? LIVE_TEST_WRONG_CHIP_RETRY_MS :
+                                                LIVE_TEST_RETRY_MS);
+            continue;
+        }
+
+        // Identified. From here every path has written something, so every path
+        // out of this loop body soft-resets the part -- including the ones where
+        // a write was not acknowledged, because a write that was not
+        // acknowledged may still have landed.
+
+        // --- Self-test --------------------------------------------------
+        memset(&st, 0, sizeof(st));
+        st.phase = LiveTestPhaseStarting;
+        st.progress_max = QMC_PROOF_STEPS;
+        snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Firing the test coil");
+        snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Hold it still.");
+        publish(ctx, &st);
+
+        int32_t delta[3] = {0};
+        const bool self_ran = qmc_self_test(i2c, addr7, stop, delta);
+        const bool self_ok = self_ran && qmc_self_test_passed(delta);
+
+        // --- Continuous measurement -------------------------------------
+        // Section 6.2.3 has the self-test drop the part into Suspend Mode when
+        // it finishes -- but only when it finishes, and the self-test above is
+        // allowed to fail halfway with 0BH already written. So the mode is
+        // established rather than assumed, and then section 7.2's example
+        // follows, all three writes, in its order.
+        const bool measuring =
+            qmc_reset(i2c, addr7, stop) &&
+            i2c->write_reg(addr7, QMC_REG_SIGN, QMC_SIGN_VALUE, LIVE_TEST_TIMEOUT_MS) &&
+            i2c->write_reg(addr7, QMC_REG_CTRL2, QMC_CTRL2_RUN, LIVE_TEST_TIMEOUT_MS) &&
+            i2c->write_reg(addr7, QMC_REG_CTRL1, QMC_CTRL1_CONT, LIVE_TEST_TIMEOUT_MS);
+
+        QmcAxisRange range[3];
+        for(uint8_t axis = 0; axis < 3; axis++) {
+            range[axis] = (QmcAxisRange){.min = INT32_MAX, .max = INT32_MIN};
+        }
+        const uint32_t started = furi_get_tick();
+        uint32_t samples = 0;
+        uint16_t overflows = 0;
+        uint8_t errors = 0;
+        bool passed = false;
+
+        while(measuring && !passed && !*stop && errors < 3) {
+            int32_t raw[3] = {0};
+            const QmcSampleResult got = qmc_read_sample(i2c, addr7, stop, raw);
+            if(got == QmcSampleOverflow) {
+                // A magnet against the case. Not a fault and not an error
+                // budget item, but it does have to reach the screen: OVFL
+                // clears on the read that saw it, so without a publish here the
+                // display would simply stop moving with no reason given.
+                overflows++;
+                memset(&st, 0, sizeof(st));
+                st.phase = LiveTestPhaseRunning;
+                st.progress = self_ok ? 1 : 0;
+                st.progress_max = QMC_PROOF_STEPS;
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Too strong - back it off");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Saturated x%u", (unsigned)overflows);
+                publish(ctx, &st);
+                continue;
+            }
+            if(got != QmcSampleOk) {
+                errors++;
+                continue;
+            }
+            errors = 0;
+            samples++;
+
+            uint8_t moved = 0;
+            for(uint8_t axis = 0; axis < 3; axis++) {
+                if(raw[axis] < range[axis].min) range[axis].min = raw[axis];
+                if(raw[axis] > range[axis].max) range[axis].max = raw[axis];
+                if(range[axis].max - range[axis].min >= QMC_MOVE_COUNTS) moved++;
+            }
+            passed = self_ok && moved >= QMC_MOVE_AXES;
+            if(passed) break; // publish it after the part is parked, not before
+
+            const float field =
+                QMC_UT_PER_G *
+                sqrtf((float)raw[0] * raw[0] + (float)raw[1] * raw[1] + (float)raw[2] * raw[2]) /
+                QMC_LSB_PER_G_RUN;
+
+            memset(&st, 0, sizeof(st));
+            st.phase = LiveTestPhaseRunning;
+            st.value = field;
+            st.progress = self_ok ? 1 : 0;
+            st.progress_max = QMC_PROOF_STEPS;
+            snprintf(st.heading, sizeof(st.heading), "%u", (unsigned)field);
+            snprintf(st.unit, sizeof(st.unit), "uT");
+            // Two lines, because a heading and progress boxes leave room for
+            // exactly two. Line 0 is the instruction and carries its own
+            // feedback; line 1 is what the coil said, which is the half the
+            // user cannot see happening.
+            snprintf(
+                st.lines[0], LIVE_TEST_LINE_LEN, "Turn it over - %u/%u axes", moved, QMC_MOVE_AXES);
+            snprintf(
+                st.lines[1],
+                LIVE_TEST_LINE_LEN,
+                self_ran ? (self_ok ? "Coil OK         %lus" : "Coil weak       %lus") :
+                           "No self-test    %lus",
+                (unsigned long)((furi_get_tick() - started) / furi_ms_to_ticks(1000)));
+            publish(ctx, &st);
+        }
+
+        // --- Park it ----------------------------------------------------
+        // One write puts everything back: section 7.6's soft reset restores the
+        // default value of all registers, which includes the sign register this
+        // test wrote and the Suspend Mode the part powers up in. Done before
+        // anything is published so the pass chime lands after the last
+        // measurement rather than during one -- this is a magnetometer and the
+        // speaker is a centimetre away.
+        const bool parked =
+            i2c->write_reg(addr7, QMC_REG_CTRL2, QMC_CTRL2_SOFTRST, LIVE_TEST_TIMEOUT_MS);
+
+        if(*stop) break;
+
+        memset(&st, 0, sizeof(st));
+        st.progress_max = QMC_PROOF_STEPS;
+        if(passed) {
+            st.phase = LiveTestPhasePassed;
+            st.progress = QMC_PROOF_STEPS;
+            snprintf(st.heading, sizeof(st.heading), "%lu", (unsigned long)samples);
+            snprintf(st.unit, sizeof(st.unit), "reads");
+            if(parked) {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "The coil fired and the");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "field followed you.");
+            } else {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Passed, but the part was");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "left running. Repower.");
+            }
+            publish(ctx, &st);
+            // Nothing is being measured and nothing is configured; this is a
+            // plain wait for Back.
+            while(!*stop)
+                qmc_delay(stop, QMC_POLL_MS);
+            break;
+        }
+
+        st.phase = LiveTestPhaseLost;
+        st.progress = self_ok ? 1 : 0;
+        if(!measuring) {
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It will not start");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "measuring. Check 3V3.");
+        } else {
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It stopped answering.");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Check 3V3 and the wires.");
+        }
+        publish(ctx, &st);
+        qmc_delay(stop, LIVE_TEST_RETRY_MS);
+    }
+}
+
+const LiveTest live_test_qmc5883p = {
+    .chip = "QMC5883P",
+    .title = "QMC5883P test",
+    .offer = "Turn it through a field",
+    .addrs = {0x2C},
+    .run = qmc_run,
+    .draw = NULL,
+};

--- a/non_catalog_apps/fake_chip_detector/live_qmc5883p.h
+++ b/non_catalog_apps/fake_chip_detector/live_qmc5883p.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "live_test.h"
+
+extern const LiveTest live_test_qmc5883p;

--- a/non_catalog_apps/fake_chip_detector/live_test.c
+++ b/non_catalog_apps/fake_chip_detector/live_test.c
@@ -10,6 +10,7 @@
 #include "live_ds3231.h"
 #include "live_mlx90614.h"
 #include "live_mpu6050.h"
+#include "live_qmc5883p.h"
 #include "live_sht.h"
 #include "live_ssd1306.h"
 #include "live_vl6180x.h"
@@ -50,6 +51,7 @@ static const LiveTest* const live_tests[] = {
     &live_test_mpu6050,
     &live_test_mpu6500,
     &live_test_mpu9250,
+    &live_test_qmc5883p,
     &live_test_sht,
     &live_test_ssd1306,
     &live_test_vl6180x,

--- a/non_catalog_apps/fake_chip_detector/live_test.c
+++ b/non_catalog_apps/fake_chip_detector/live_test.c
@@ -2,6 +2,7 @@
 #include "i2c_worker.h"
 
 #include "live_adxl345.h"
+#include "live_ak09911.h"
 #include "live_aht.h"
 #include "live_apds9960.h"
 #include "live_bh1750.h"
@@ -39,6 +40,7 @@ const LiveTestI2c* live_test_i2c(void) {
 // lookup is by chip name, so it does not otherwise matter.
 static const LiveTest* const live_tests[] = {
     &live_test_adxl345,
+    &live_test_ak09911,
     &live_test_aht,
     &live_test_apds9960,
     &live_test_bh1750,

--- a/non_catalog_apps/fake_chip_detector/live_vl6180x.c
+++ b/non_catalog_apps/fake_chip_detector/live_vl6180x.c
@@ -183,14 +183,19 @@ static void vl6180x_run(const LiveTestEnv* env) {
                 snprintf(detail, sizeof(detail), "err 0x%X", error_code);
             }
 
+            // The proof stands once the distance has moved with a hand: that
+            // happened and no later reading unhappens it. What the banner may
+            // not do is describe the present tense wrongly. Saying "it tracks"
+            // over a reading the part itself rejected puts the app in an
+            // argument with its own number, and the number wins every time.
             st.phase = proved ? LiveTestPhasePassed : LiveTestPhaseRunning;
-            vl6180x_set_lines(
-                &st,
-                proved          ? "It tracks - real sensor" :
-                error_code == 0 ? "Move your hand closer" :
-                                  "Hold a hand 5cm away",
-                detail,
-                NULL);
+            const char* headline;
+            if(proved) {
+                headline = error_code == 0 ? "It tracks - real sensor" : "It tracked earlier";
+            } else {
+                headline = error_code == 0 ? "Move your hand closer" : "Hold a hand 5cm away";
+            }
+            vl6180x_set_lines(&st, headline, detail, NULL);
             publish(ctx, &st);
 
             vl6180x_delay(stop, VL6180X_POLL_MS);

--- a/non_catalog_apps/fake_chip_detector/onewire_worker.c
+++ b/non_catalog_apps/fake_chip_detector/onewire_worker.c
@@ -8,19 +8,12 @@
 // Family codes come from Maxim/Analog application note AN937 and the parts'
 // own datasheets. The family code is not a hint: it selects the command set,
 // so reading a different one than the label promises is a hard fact.
-typedef struct {
-    uint8_t family;
-    const char* name;
-    const char* kind;
-    OneWireRole role;
-} OneWireFamily;
-
 static const OneWireFamily onewire_families[] = {
     {0x01, "DS1990A/DS2401", "Serial number key", OneWireRoleOther},
-    {0x04, "DS2404", "Clock + memory", OneWireRoleMemory},
+    {0x04, "DS2404", "Clock + memory chip", OneWireRoleMemory},
     {0x05, "DS2405", "Addressable switch", OneWireRoleSwitch},
     {0x10, "DS18S20", "Temperature sensor", OneWireRoleTemperature},
-    {0x1D, "DS2423", "RAM + counter", OneWireRoleMemory},
+    {0x1D, "DS2423", "RAM + counter chip", OneWireRoleMemory},
     {0x20, "DS2450", "4-channel ADC", OneWireRoleOther},
     {0x22, "DS1822", "Temperature sensor", OneWireRoleTemperature},
     {0x26, "DS2438", "Battery monitor", OneWireRoleOther},
@@ -40,6 +33,15 @@ static const OneWireFamily onewire_families[] = {
 // Datasheet worst case for a 12-bit conversion is 750 ms; the margin costs
 // nothing and a truncated wait reads back a stale or garbage temperature.
 #define ONEWIRE_CONVERT_MS 800
+
+size_t onewire_family_count(void) {
+    return COUNT_OF(onewire_families);
+}
+
+const OneWireFamily* onewire_family_get(size_t index) {
+    if(index >= COUNT_OF(onewire_families)) return NULL;
+    return &onewire_families[index];
+}
 
 static const OneWireFamily* onewire_family_lookup(uint8_t family_code) {
     for(size_t i = 0; i < COUNT_OF(onewire_families); i++) {

--- a/non_catalog_apps/fake_chip_detector/onewire_worker.h
+++ b/non_catalog_apps/fake_chip_detector/onewire_worker.h
@@ -24,6 +24,19 @@ typedef enum {
     OneWireRoleOther,
 } OneWireRole;
 
+// One row of the family table: what a given family code means. The table is
+// also what the app can honestly claim to recognise on this bus, so it is
+// public — a count that leaves it out under-reports the app's own coverage.
+typedef struct {
+    uint8_t family;
+    const char* name;
+    const char* kind;
+    OneWireRole role;
+} OneWireFamily;
+
+size_t onewire_family_count(void);
+const OneWireFamily* onewire_family_get(size_t index); // NULL when out of range
+
 typedef struct {
     uint8_t rom[8]; // [0] family code, [1..6] serial, [7] CRC8
     bool crc_ok; // ROM CRC8 checks out

--- a/non_catalog_apps/fake_chip_detector/report.c
+++ b/non_catalog_apps/fake_chip_detector/report.c
@@ -1,17 +1,345 @@
 #include "report.h"
 #include "chip_db.h"
 
+#include <string.h>
+
+static bool is_upper(char c) {
+    return c >= 'A' && c <= 'Z';
+}
+
+static bool is_lower(char c) {
+    return c >= 'a' && c <= 'z';
+}
+
+static bool is_digit(char c) {
+    return c >= '0' && c <= '9';
+}
+
+// "a" or "an", decided by how the next word is said out loud rather than by
+// the letter it starts with. In this app's vocabulary the two disagree
+// constantly: an 8-channel switch but a 6-axis IMU, an MPU6050 but a BNO055,
+// and a UV sensor even though U is a vowel. A small thing, and it lands in the
+// first line of a document someone reads aloud at a front door.
+const char* report_article(const char* word) {
+    if(!word || !word[0]) return "a";
+
+    // Numbers first, before the spelled-out test below, which would otherwise
+    // claim "1Kb EEPROM" on the strength of its capital K. Only the first
+    // syllable matters: eight, eleven and eighteen begin with a vowel and no
+    // other number does, and 80 or 800 still begin with "eight".
+    if(is_digit(word[0])) {
+        if(word[0] == '8') return "an";
+        if(word[0] == '1' && (word[1] == '1' || word[1] == '8') && !is_digit(word[2])) return "an";
+        return "a";
+    }
+
+    size_t letters = 0;
+    while(is_upper(word[letters]) || is_lower(word[letters]))
+        letters++;
+
+    // Acronyms the world says as a word instead of spelling out. The letter
+    // rule below gets them backwards -- "an RAM + counter chip", "an MAX30102" --
+    // and the comparison is against the letters alone, because the string is
+    // MAX30102 and not MAX. Add a line here when a new part starts with one.
+    static const char* const said_as_a_word[] = {"RAM", "MAX"};
+    for(size_t i = 0; i < COUNT_OF(said_as_a_word); i++) {
+        if(strlen(said_as_a_word[i]) == letters && strncmp(word, said_as_a_word[i], letters) == 0)
+            return "a";
+    }
+
+    // Two capitals running, or a capital then a digit, means the letters are
+    // read out one at a time -- and then it is the name of the first letter
+    // that decides. An "ess", an "em", an "aitch"; but a "you", which is why
+    // UV and USB take "a".
+    if(is_upper(word[0]) && !is_lower(word[1])) {
+        return strchr("AEFHILMNORSX", word[0]) ? "an" : "a";
+    }
+
+    char first = is_upper(word[0]) ? (char)(word[0] - 'A' + 'a') : word[0];
+    return strchr("aeiou", first) ? "an" : "a";
+}
+
+// A kind is written to stand on its own under a part number on the screen --
+// "Air quality sensor" -- and here it has to sit in the middle of a sentence
+// instead: article in front, capital dropped. The capital stays when the word
+// is one the world writes in capitals, EEPROM and GPIO and I2C, which is the
+// same test as "is the second letter lower case". That is also why lowering
+// can never change the article: a word with a lower-case second letter was
+// never being spelled out in the first place.
+void report_phrase_kind(char* out, size_t size, const char* kind) {
+    const char* article = report_article(kind);
+    if(is_upper(kind[0]) && is_lower(kind[1])) {
+        snprintf(out, size, "%s %c%s", article, (char)(kind[0] - 'A' + 'a'), kind + 1);
+    } else {
+        snprintf(out, size, "%s %s", article, kind);
+    }
+}
+
 // Written to be read aloud at a front door, by someone who has never heard of
 // I2C. Plain statement first, then why the evidence cannot be faked, and only
 // at the very bottom the register values an engineer would want.
+
+// What the listen heard, or did not. Three outcomes and three different
+// paragraphs: a document that printed "nothing was transmitting" when the app
+// never got as far as listening would be claiming a measurement it did not
+// make, in writing, to somebody who is going to show it to a seller.
+static void report_silence_listen(FuriString* out, const SilentDiagnosis* s) {
+    const UartListenResult* r = &s->listen;
+
+    switch(s->listen_outcome) {
+    case UartListenHeard:
+        if(r->bytes) {
+            furi_string_cat_printf(
+                out,
+                "The same two pins were then listened to as a plain serial line, and something "
+                "was transmitting on them: %u bytes at %lu baud, with no framing errors. ",
+                (unsigned)r->bytes,
+                (unsigned long)r->baud);
+            if(r->sample_len) {
+                // The bytes themselves, because a reader who knows the part
+                // can recognise them and a reader who does not can still show
+                // them to someone who can.
+                furi_string_cat_str(out, "The first of them were");
+                size_t show = r->sample_len < 16 ? r->sample_len : 16;
+                for(size_t i = 0; i < show; i++) {
+                    furi_string_cat_printf(out, " %02X", r->sample[i]);
+                }
+                furi_string_cat_str(out, show < r->sample_len ? " ...\n" : ".\n");
+            }
+            furi_string_cat_str(
+                out,
+                "A part that is transmitting is powered and running. It is not answering on "
+                "I2C because it is not speaking I2C.\n\n");
+        } else {
+            // Framing errors and not one clean byte. Naming a rate here would
+            // be reporting the guess rather than the measurement.
+            furi_string_cat_str(
+                out,
+                "The same two pins were then listened to as a plain serial line. Something was "
+                "switching the line, but not at any of the rates tried, so nothing could be "
+                "read off it. Even so, a pin that is being driven is being driven by something "
+                "powered and running.\n\n");
+        }
+        break;
+
+    case UartListenSilent:
+        furi_string_cat_str(
+            out,
+            "The same two pins were then listened to as a plain serial line, at four common "
+            "rates, for about two seconds in all. Nothing arrived. That is not the same as "
+            "proof that nothing is there: a part that only speaks when it is spoken to says "
+            "nothing to a listener, and a module that reports once a second can fall between "
+            "windows that short.\n\n");
+        break;
+
+    default:
+        // Never listened. Saying nothing here would let the report read as
+        // though only I2C had ever been tried, which is a different account of
+        // what the app did.
+        furi_string_cat_str(
+            out,
+            "The serial line on those same two pins could not be listened to on this run, so "
+            "nothing about it can be said either way.\n\n");
+        break;
+    }
+}
+
+// Nothing identified itself, so the app cannot say which part is on the board.
+// What it can say is which parts carry a pin of this class -- and that is what
+// makes the measurement checkable, because the reader can hold the list
+// against the module in their hand. It is also the difference between "a pin
+// read low" and a sentence a seller has to answer.
+static void report_silence_known(FuriString* out, const SilentDiagnosis* s) {
+    if(!s->pad_mode_known) return; // the address row: those pads pick no bus
+
+    // Only the level that takes the part off the bus is worth a list. Naming
+    // SPI-selecting parts under a reading that says the pad is fine would be
+    // arguing against the app's own measurement. Floating is wrong on every
+    // mode pin: the datasheets forbid it, and whatever such a pad settles on
+    // at power-up is chance.
+    bool wrong = s->pad_level == I2CPadFloating ||
+                 s->pad_level == (s->pad_wanted_high ? I2CPadLow : I2CPadHigh);
+    if(!wrong) return;
+
+    size_t total = 0;
+    size_t latched = 0;
+    for(size_t i = 0; i < chip_mode_pin_count(); i++) {
+        const ChipModePin* p = chip_mode_pin_get(i);
+        if(!chip_mode_pin_matches(p, s->pad_mode_kind, s->pad_mode_alt, s->pad_wanted_high))
+            continue;
+        total++;
+        if(p->latched) latched++;
+    }
+    if(!total) return; // a class no row in this build has been verified for
+
+    // Singular and plural threaded through as fragments rather than as two
+    // copies of every sentence. One part is not the rare case here: BNO055 is
+    // the whole reason this screen exists.
+    bool one = total == 1;
+
+    if(s->pad_level == I2CPadFloating) {
+        furi_string_cat_printf(
+            out,
+            "A pin of that kind is not allowed to float, and the level it settles on at "
+            "power-up is chance rather than a setting. %s: ",
+            one ? "This tool knows of one part with such a pin" :
+                  "These are the parts this tool knows that have one");
+    } else {
+        const char* went = s->pad_mode_alt == ModeAltUart ?
+                               "hands the part to a serial line, where it has no I2C address "
+                               "at all" :
+                           s->pad_mode_alt == ModeAltSpi ?
+                               "hands the part to SPI, which switches its I2C interface off" :
+                               "holds the part shut down";
+        furi_string_cat_printf(
+            out,
+            "On the %s this tool knows with a pin marked that way, that level %s: ",
+            one ? "one part" : "parts",
+            went);
+    }
+
+    // Each part with the pad name from its own datasheet, not the family's list
+    // of labels: a row whose silkscreen name is not one of those four is then
+    // visible as itself instead of being quietly filed under the wrong heading.
+    size_t printed = 0;
+    for(size_t i = 0; i < chip_mode_pin_count(); i++) {
+        const ChipModePin* p = chip_mode_pin_get(i);
+        if(!chip_mode_pin_matches(p, s->pad_mode_kind, s->pad_mode_alt, s->pad_wanted_high))
+            continue;
+        furi_string_cat_printf(out, "%s%s (%s)", printed++ ? ", " : "", p->chip, p->pad);
+    }
+    furi_string_cat_str(out, ". ");
+
+    if(latched == total) {
+        furi_string_cat_printf(
+            out,
+            "That choice is latched when the power comes up%s, so holding the pad the other "
+            "way changes nothing until the power has been cycled. ",
+            one ? "" : " on all of them");
+    } else if(latched) {
+        furi_string_cat_str(out, "On ");
+        printed = 0;
+        for(size_t i = 0; i < chip_mode_pin_count(); i++) {
+            const ChipModePin* p = chip_mode_pin_get(i);
+            if(!chip_mode_pin_matches(p, s->pad_mode_kind, s->pad_mode_alt, s->pad_wanted_high))
+                continue;
+            if(!p->latched) continue;
+            furi_string_cat_printf(out, "%s%s", printed++ ? ", " : "", p->chip);
+        }
+        furi_string_cat_str(
+            out,
+            " that choice is latched when the power comes up, so holding the pad the other "
+            "way changes nothing until the power has been cycled. The rest read the pin "
+            "continuously. ");
+    } else {
+        // No family reaches this today, and the enable pins will: a part held
+        // in reset reads that pin the whole time it is running, so the moment
+        // rows like XSHUT are verified this is the branch they land in.
+        furi_string_cat_str(
+            out, "These read the pin continuously, so the level above is the one that counted. ");
+    }
+
+    // The list is what parts of this kind do, never what this board is. Saying
+    // so in the same breath is the difference between evidence and a guess
+    // dressed as evidence.
+    furi_string_cat_printf(
+        out,
+        "Whether %s what is on this board is unknown: nothing answered, so nothing "
+        "identified itself.\n\n",
+        one ? "that part is" : "one of those parts is");
+}
+
+// The nothing-answered document. Deliberately refuses to conclude: everything
+// here is either a measurement or a fact about how these parts are built, and
+// the one sentence a reader will act on says plainly that none of it is
+// evidence the chip is broken.
+static void report_silence(FuriString* out, const SilentDiagnosis* s) {
+    furi_string_cat_str(out, "NOTHING ANSWERED ON THE I2C BUS\n\n");
+
+    switch(s->bus.health) {
+    case I2CBusStuckLow:
+        furi_string_cat_str(
+            out,
+            "A data line is held low. That is a wiring fault or a chip that has hung, "
+            "and it has to be fixed before anything can be said about the part.\n\n");
+        break;
+    case I2CBusFloating:
+        furi_string_cat_str(
+            out,
+            "Neither data line is pulled up, so the module is either unpowered or not "
+            "connected. Nothing can be concluded about the chip from this.\n\n");
+        break;
+    default:
+        furi_string_cat_str(
+            out,
+            "The bus itself was electrically healthy: the module had power and its "
+            "pull-up resistors were present on both lines. Something is connected and "
+            "it did not answer.\n\n");
+        break;
+    }
+
+    // Only where it was tried. The listen runs after a sweep that came back
+    // empty on a healthy bus, and only there -- on a bus with no pull-ups the
+    // receive pin drifts, and drift alone can look like traffic. Reporting on
+    // a listen that was never applicable would be answering a question nobody
+    // asked.
+    if(s->bus.health == I2CBusOk) report_silence_listen(out, s);
+
+    if(s->pad_measured && s->pad_labels) {
+        const char* level = s->pad_level == I2CPadHigh ? "HIGH" :
+                            s->pad_level == I2CPadLow  ? "LOW" :
+                                                         "floating";
+        furi_string_cat_printf(out, "The pin marked %s measured %s.\n\n", s->pad_labels, level);
+
+        if(s->pad_held) {
+            furi_string_cat_printf(
+                out,
+                "Pulling that pin %s did not move it, so it is tied %s on the board itself. "
+                "The module was built this way and no rewiring can change it.\n\n",
+                s->pad_wanted_high ? "up" : "down",
+                s->pad_wanted_high ? "low" : "high");
+        }
+
+        report_silence_known(out, s);
+    }
+
+    furi_string_cat_str(
+        out,
+        "WHY THIS IS NOT PROOF OF A FAULT\n"
+        "Many sensors have a pin that chooses which kind of connection they use. Set one "
+        "way the chip talks I2C; set the other it talks SPI or a serial line instead, and "
+        "then it has no I2C address at all and cannot answer, however healthy it is. That "
+        "pin is often decided by the board rather than by the buyer. An empty scan is "
+        "therefore a reason to look closer, not a reason to call the part defective.\n\n");
+}
 
 void report_build(
     FuriString* out,
     const I2CFoundDevice* found,
     uint8_t count,
     bool disputed,
-    const DateTime* dt) {
+    const DateTime* dt,
+    const SilentDiagnosis* silent) {
     furi_string_reset(out);
+
+    if(count == 0 && silent) {
+        report_silence(out, silent);
+        furi_string_cat_printf(
+            out,
+            "Checked %04u-%02u-%02u %02u:%02u with Fake Chip Detector on a Flipper Zero.\n\n"
+            "--- TECHNICAL DETAIL ---\n"
+            "Bus: I2C, 100 kHz. Swept every 7-bit address, 0x08 to 0x77.\n"
+            "SCL pull-up: %s   SDA pull-up: %s   Lines shorted: %s\n",
+            dt->year,
+            dt->month,
+            dt->day,
+            dt->hour,
+            dt->minute,
+            silent->bus.scl_ok ? "yes" : "no",
+            silent->bus.sda_ok ? "yes" : "no",
+            silent->bus.shorted ? "yes" : "no");
+        return;
+    }
 
     if(disputed) {
         furi_string_cat_str(
@@ -28,8 +356,11 @@ void report_build(
         const char* kind = dev->ident.chip ? dev->ident.chip->kind : NULL;
 
         if(name && kind) {
-            furi_string_cat_printf(out, "The chip inside this module is a %s.\n", name);
-            furi_string_cat_printf(out, "That part is a %s.\n\n", kind);
+            char phrase[48];
+            furi_string_cat_printf(
+                out, "The chip inside this module is %s %s.\n", report_article(name), name);
+            report_phrase_kind(phrase, sizeof(phrase), kind);
+            furi_string_cat_printf(out, "That part is %s.\n\n", phrase);
         } else {
             furi_string_cat_str(
                 out, "A chip answered, but it does not identify itself as any known part.\n\n");
@@ -56,6 +387,31 @@ void report_build(
             furi_string_cat_str(
                 out, "The chip acknowledged its address but returned no data.\n\n");
             break;
+        case VerdictAmbiguous: {
+            // The report is the one place with room to name them, and naming
+            // them is the difference between a verdict somebody can act on and
+            // a shrug. What it must not do is imply the tool narrowed it down
+            // further than it did, so the list is complete or it says so.
+            const ChipEntry* cands[8] = {0};
+            const size_t total = chip_db_no_id_at(dev->addr, cands, COUNT_OF(cands));
+            if(total == dev->ident.candidates && total > 0) {
+                furi_string_cat_str(
+                    out,
+                    "More than one part lives at this address and none of them carries a "
+                    "factory ID, so nothing read here can tell them apart. It is one of: ");
+                for(size_t c = 0; c < total && c < COUNT_OF(cands); c++) {
+                    furi_string_cat_printf(out, "%s%s", c ? ", " : "", cands[c]->name);
+                }
+                furi_string_cat_str(out, ".\n\n");
+            } else {
+                furi_string_cat_printf(
+                    out,
+                    "%u known parts answer the ID registers read here equally well, so this "
+                    "tool will not pick one of them.\n\n",
+                    (unsigned)dev->ident.candidates);
+            }
+            break;
+        }
         default:
             furi_string_cat_str(out, "The ID it reported matches no chip known to this tool.\n\n");
             break;
@@ -120,4 +476,183 @@ void report_build(
         }
     }
     if(count == 0) furi_string_cat_str(out, "No devices found\n");
+}
+
+// One place decides how a tenth-of-a-degree reading is spelled, because the
+// obvious way is wrong. Dividing tenths by ten and printing it with %d loses
+// the sign everywhere between -0.9 and -0.1 C: C truncates toward zero, so the
+// whole part of -5 tenths is 0, and "0" has no minus to print. A sensor in a
+// freezer would report half a degree above zero.
+static void report_cat_temp(FuriString* out, float temp_c) {
+    int tenths = (int)(temp_c * 10.0f);
+    int mag = tenths < 0 ? -tenths : tenths;
+    furi_string_cat_printf(out, "%s%d.%d", tenths < 0 ? "-" : "", mag / 10, mag % 10);
+}
+
+// Every part in the 1-Wire temperature families this app decodes measures
+// -55..+125 C. A number outside that is not a temperature, and reading "it
+// works" off it would be exactly the kind of claim this app exists to stop.
+#define OW_TEMP_MIN_TENTHS (-550)
+#define OW_TEMP_MAX_TENTHS 1250
+
+void report_build_onewire(FuriString* out, const OneWireScanResult* res, const DateTime* dt) {
+    furi_string_reset(out);
+    furi_string_cat_str(out, "1-WIRE INSPECTION REPORT\n\n");
+
+    if(res->count == 0) {
+        switch(res->state) {
+        case OneWireBusShorted:
+            furi_string_cat_str(
+                out,
+                "Nothing could be read. The data line stayed low the whole time, which means "
+                "it is shorted to ground or the 4.7k pull-up resistor is missing. No "
+                "conclusion about any part can be drawn from this.\n\n");
+            break;
+        case OneWireBusEmpty:
+            furi_string_cat_str(
+                out,
+                "No device answered. Nothing on the bus responded to the signal that every "
+                "1-Wire part must answer, so either nothing is connected to the data wire or "
+                "it has no power.\n\n");
+            break;
+        default:
+            // A presence pulse came back and then the ID search returned
+            // nothing. Something is on the wire; saying "no device" would
+            // throw away the one fact this run did establish.
+            furi_string_cat_str(
+                out,
+                "Something on the bus answered the first signal, but then gave no ID when "
+                "asked for one. A part is connected; it did not identify itself.\n\n");
+            break;
+        }
+    }
+
+    for(uint8_t i = 0; i < res->count; i++) {
+        const OneWireDevice* dev = &res->found[i];
+
+        if(dev->name && dev->kind) {
+            char phrase[48];
+            furi_string_cat_printf(
+                out, "The part on this bus is %s %s.\n", report_article(dev->name), dev->name);
+            report_phrase_kind(phrase, sizeof(phrase), dev->kind);
+            furi_string_cat_printf(out, "That part is %s.\n", phrase);
+        } else {
+            furi_string_cat_printf(
+                out,
+                "A device answered with family code 0x%02X, which is not a part this tool "
+                "knows.\n",
+                dev->rom[0]);
+        }
+
+        if(!dev->crc_ok) {
+            furi_string_cat_str(
+                out,
+                "Its ID failed the checksum carried inside the ID itself, so the number was "
+                "misread and nothing above it should be relied on. Check the wiring and read "
+                "it again.\n\n");
+            continue;
+        }
+
+        int tenths = (int)(dev->temp_c * 10.0f);
+        if(dev->measured && dev->scratch_crc_ok && tenths >= OW_TEMP_MIN_TENTHS &&
+           tenths <= OW_TEMP_MAX_TENTHS) {
+            furi_string_cat_str(out, "It was asked for a temperature and answered ");
+            report_cat_temp(out, dev->temp_c);
+            furi_string_cat_str(
+                out, " C, so the measuring part of it works and not only the ID.\n\n");
+        } else if(dev->measured && dev->scratch_crc_ok) {
+            furi_string_cat_str(
+                out,
+                "It answered a temperature outside the range this kind of part can measure, "
+                "so the reading proves nothing about it.\n\n");
+        } else if(dev->measured) {
+            furi_string_cat_str(
+                out,
+                "It answered a measurement, but the data failed its own checksum, so the "
+                "number could not be trusted and is not printed here.\n\n");
+        } else if(dev->role == OneWireRoleTemperature) {
+            furi_string_cat_str(
+                out, "No temperature came back from it, so only its identity was checked.\n\n");
+        } else {
+            furi_string_cat_str(
+                out,
+                "It is present and its ID checks out. This kind of part has nothing to "
+                "measure, so that is as far as the check goes.\n\n");
+        }
+    }
+
+    // The flag exists to be reported. A list of eight that was really a bus of
+    // twelve reads as a complete inventory, and the reader has no way to know.
+    if(res->overflow) {
+        furi_string_cat_printf(
+            out,
+            "There were more devices on this bus than this tool can list. The %u above are "
+            "the ones it reached; this is not a complete inventory.\n\n",
+            res->count);
+    }
+
+    furi_string_cat_str(
+        out,
+        "HOW THIS WAS CHECKED\n"
+        "Every 1-Wire part carries a 64-bit number burned into it at the factory, and the "
+        "lowest byte of that number says which kind of part it is. This tool read the "
+        "number over the single data wire, checked it against the checksum built into it, "
+        "and decoded it.\n\n"
+        "Read this next part before relying on the one above. A 1-Wire number can be "
+        "copied: any microcontroller can be programmed to answer with someone else's, so "
+        "this document says which part answered, not who made it. What it does catch is "
+        "the substitution that actually happens - a cheaper part of a different kind sold "
+        "under a popular name - because a genuine part announces its own kind and has no "
+        "way to announce another. Anyone can repeat this test with the same free tool and "
+        "get the same result.\n\n");
+
+    furi_string_cat_printf(
+        out,
+        "Checked %04u-%02u-%02u %02u:%02u with Fake Chip Detector on a Flipper Zero.\n\n",
+        dt->year,
+        dt->month,
+        dt->day,
+        dt->hour,
+        dt->minute);
+
+    furi_string_cat_str(out, "--- TECHNICAL DETAIL ---\nBus: 1-Wire, header pin 17\n");
+
+    switch(res->state) {
+    case OneWireBusShorted:
+        furi_string_cat_str(out, "bus: held low, search not attempted\n");
+        break;
+    case OneWireBusEmpty:
+        furi_string_cat_str(out, "bus: no presence pulse\n");
+        break;
+    default:
+        break;
+    }
+
+    for(uint8_t i = 0; i < res->count; i++) {
+        const OneWireDevice* dev = &res->found[i];
+        // 16 hex digits with no separators, the same shape the screen shows:
+        // it is an identifier to compare against a listing, not prose.
+        furi_string_cat_str(out, "rom ");
+        for(uint8_t b = 0; b < 8; b++) {
+            furi_string_cat_printf(out, "%02X", dev->rom[b]);
+        }
+        furi_string_cat_printf(out, " %s\n", dev->name ? dev->name : "UNKNOWN");
+        furi_string_cat_printf(
+            out, " family 0x%02X, ROM CRC %s\n", dev->rom[0], dev->crc_ok ? "OK" : "BAD");
+        if(dev->measured && dev->scratch_crc_ok) {
+            furi_string_cat_str(out, " temp ");
+            report_cat_temp(out, dev->temp_c);
+            furi_string_cat_str(out, " C, scratchpad CRC OK\n");
+        } else if(dev->measured) {
+            // temp_c is left at zero when the scratchpad fails its checksum,
+            // and printing that zero next to a BAD would read as 0.0 C.
+            furi_string_cat_str(out, " scratchpad CRC BAD, no reading\n");
+        }
+    }
+
+    if(res->overflow) {
+        furi_string_cat_printf(
+            out, "more than %u devices on the bus; the list above stops there\n", res->count);
+    }
+    if(res->count == 0) furi_string_cat_str(out, "No devices found\n");
 }

--- a/non_catalog_apps/fake_chip_detector/report.h
+++ b/non_catalog_apps/fake_chip_detector/report.h
@@ -4,11 +4,55 @@
 #include <datetime/datetime.h>
 
 #include "i2c_worker.h"
+#include "onewire_worker.h"
+#include "uart_listen.h"
 
 // Builds the human-readable report. The same text is what the screen shows
 // and what lands on the SD card — a report you hand to a courier must not
 // differ from the file you email afterwards.
 //
+// What the app managed to establish when nothing answered at all. NULL on the
+// normal path. The person who most needs a document is the one whose chip
+// never spoke -- they are the one being told to accept or refuse a parcel with
+// no evidence either way -- and until this existed they were the only user who
+// could not save one.
+typedef struct {
+    I2CBusCheck bus;
+    bool pad_measured; // the user walked a wire onto a mode pad
+    uint8_t pad_level; // I2CPadLevel
+    const char* pad_labels; // the family of labels they said they were on
+    // A weak pull the other way was tried and lost, so the pad is tied in
+    // copper. For a buyer that is the whole answer: the seller shipped a board
+    // configured off the I2C bus, and no amount of rewiring at a counter will
+    // change it.
+    bool pad_held;
+    bool pad_wanted_high; // the level I2C needed, for the sentence above
+    // Which class of mode pin those labels belong to, so the report can name
+    // the parts that have one. False for the address row, whose labels pick no
+    // bus at all; when false the two fields below mean nothing. Together with
+    // pad_wanted_high this is the key into chip_mode_pin_matches().
+    bool pad_mode_known;
+    uint8_t pad_mode_kind; // ModePinKind
+    uint8_t pad_mode_alt; // ModeAlt: where a wrong level sends the part
+    // What the automatic listen after the empty sweep established. The zero
+    // value is UartListenUnavailable -- "never listened" -- which is the right
+    // answer for a report built before the listen could run, and is a
+    // different sentence from "listened and heard nothing".
+    uint8_t listen_outcome; // UartListenOutcome
+    UartListenResult listen;
+} SilentDiagnosis;
+
+// Prose helpers, exported because the screen has to say the same phrase the
+// report does. "You were sold a 8-channel switch" was on the screen and in the
+// document, and it is the sort of thing a seller points at.
+const char* report_article(const char* word);
+
+// Article and capital together, because the same first word decides both:
+// report_phrase_kind(buf, sizeof(buf), "Air quality sensor") writes
+// "an air quality sensor". Pass a kind, not a part number -- a name keeps its
+// capital, so Si7021 must go through report_article on its own.
+void report_phrase_kind(char* out, size_t size, const char* kind);
+
 // disputed: the buyer has said this is not the part they ordered, which turns
 // the document from an inspection note into a reason for refusing delivery.
 void report_build(
@@ -16,4 +60,16 @@ void report_build(
     const I2CFoundDevice* found,
     uint8_t count,
     bool disputed,
-    const DateTime* dt);
+    const DateTime* dt,
+    const SilentDiagnosis* silent);
+
+// A separate document, not another section of the one above. What gives the
+// I2C report its force is the paragraph saying the factory ID is read-only and
+// no seller can change it — and that sentence is simply untrue of a 1-Wire ROM
+// code, which any microcontroller can replay. Sharing the paragraph would put
+// the app's one real overclaim into the page a user hands to a courier.
+//
+// There is no disputed flavour here on purpose: the 1-Wire screen never asks
+// what the buyer ordered, and it does not need to. The decoded part name and
+// its family code are the refusal evidence by themselves.
+void report_build_onewire(FuriString* out, const OneWireScanResult* res, const DateTime* dt);

--- a/non_catalog_apps/fake_chip_detector/uart_listen.c
+++ b/non_catalog_apps/fake_chip_detector/uart_listen.c
@@ -1,0 +1,273 @@
+#include "uart_listen.h"
+
+#include <furi.h>
+#include <furi_hal_serial.h>
+#include <furi_hal_serial_control.h>
+#include <furi_hal_resources.h>
+#include <expansion/expansion.h>
+
+#define TAG "UartListen"
+
+// Enough for a GPS sentence or a couple of PM-sensor frames. Anything past this
+// is dropped in the interrupt rather than blocking it: what matters is that
+// something is talking and at which rate, not capturing all of it.
+#define UART_RX_BUFFER 256
+
+typedef struct {
+    FuriStreamBuffer* rx;
+    volatile uint32_t frame_errors;
+} UartRxContext;
+
+// Runs in an interrupt. Nothing here may block, allocate, or take a mutex --
+// which is why the byte goes into a stream buffer with a zero timeout and the
+// error count is a plain increment.
+static void uart_rx_callback(FuriHalSerialHandle* handle, FuriHalSerialRxEvent event, void* ctx) {
+    UartRxContext* c = ctx;
+    if(event & FuriHalSerialRxEventData) {
+        uint8_t byte = furi_hal_serial_async_rx(handle);
+        furi_stream_buffer_send(c->rx, &byte, 1, 0);
+    }
+    // A wrong baud rate does not read as silence, it reads as garbage with
+    // framing errors. Counting them is what lets the sweep pick a rate on
+    // evidence instead of on the first thing that produced bytes.
+    if(event & (FuriHalSerialRxEventFrameError | FuriHalSerialRxEventNoiseError)) {
+        c->frame_errors++;
+    }
+}
+
+// The expansion service owns LPUART and will fight for it. Standing it down is
+// a documented requirement, not a precaution -- and the record may not exist on
+// every firmware this app is built for, so its absence is not an error.
+static Expansion* uart_expansion_stand_down(void) {
+    if(!furi_record_exists(RECORD_EXPANSION)) return NULL;
+    Expansion* expansion = furi_record_open(RECORD_EXPANSION);
+    expansion_disable(expansion);
+    return expansion;
+}
+
+static void uart_expansion_restore(Expansion* expansion) {
+    if(!expansion) return;
+    expansion_enable(expansion);
+    furi_record_close(RECORD_EXPANSION);
+}
+
+// Trusting a comment about which pin is which is how you end up debugging the
+// wrong wire. The HAL knows; ask it.
+static bool uart_pinout_is_expected(FuriHalSerialHandle* handle) {
+    const GpioPin* rx = furi_hal_serial_get_gpio_pin(handle, FuriHalSerialDirectionRx);
+    const GpioPin* tx = furi_hal_serial_get_gpio_pin(handle, FuriHalSerialDirectionTx);
+    return rx == &gpio_ext_pc0 && tx == &gpio_ext_pc1;
+}
+
+// Acquire, run body, release -- in one function with no early return between
+// the halves. A leaked serial handle takes the expansion service down until the
+// Flipper is rebooted, which is a far worse outcome than any failure this code
+// is trying to report.
+typedef bool (*UartSession)(FuriHalSerialHandle* handle, UartRxContext* rx, void* context);
+
+//
+// ran, when given, reports whether the body was reached at all. Every reason it
+// might not be -- the handle held elsewhere, the peripheral on different pins --
+// leaves the caller knowing nothing about the wire, which is a different answer
+// from having listened and heard silence.
+static bool uart_with_lpuart(uint32_t baud, UartSession body, void* context, bool* ran) {
+    if(ran) *ran = false;
+    if(!body) return false;
+
+    Expansion* expansion = uart_expansion_stand_down();
+    FuriHalSerialHandle* handle = furi_hal_serial_control_acquire(FuriHalSerialIdLpuart);
+    bool ok = false;
+
+    if(!handle) {
+        // Somebody else has it. A screen, not an assert.
+        FURI_LOG_W(TAG, "LPUART busy");
+    } else {
+        furi_hal_serial_init(handle, baud);
+
+        if(!uart_pinout_is_expected(handle)) {
+            // The pins are the entire premise: the same two holes the I2C bus
+            // is already in. If a firmware moves LPUART somewhere else, every
+            // instruction this app gives about pin 15 and pin 16 becomes wrong,
+            // so it stops rather than talking to whatever is there.
+            FURI_LOG_E(TAG, "LPUART is not on PC0/PC1 on this firmware");
+        } else {
+            UartRxContext rx = {
+                .rx = furi_stream_buffer_alloc(UART_RX_BUFFER, 1),
+                .frame_errors = 0,
+            };
+            furi_hal_serial_async_rx_start(handle, uart_rx_callback, &rx, true);
+            if(ran) *ran = true;
+            ok = body(handle, &rx, context);
+            furi_hal_serial_async_rx_stop(handle);
+            furi_stream_buffer_free(rx.rx);
+        }
+
+        furi_hal_serial_deinit(handle);
+        furi_hal_serial_control_release(handle);
+    }
+
+    uart_expansion_restore(expansion);
+    return ok;
+}
+
+/* ---- listening ---- */
+
+typedef struct {
+    const uint32_t* bauds;
+    size_t baud_count;
+    uint32_t window_ms;
+    const volatile bool* abort;
+    UartListenResult best;
+    bool found;
+} ListenJob;
+
+// The window, waited in slices so that leaving the app does not have to sit
+// through the rest of one. Returns false if the flag went up: the caller still
+// reads out what arrived before that, because bytes heard are bytes heard.
+static bool listen_wait(uint32_t ms, const volatile bool* abort) {
+    const uint32_t slice = 25;
+    for(uint32_t waited = 0; waited < ms; waited += slice) {
+        if(abort && *abort) return false;
+        uint32_t left = ms - waited;
+        furi_delay_ms(left < slice ? left : slice);
+    }
+    return !(abort && *abort);
+}
+
+// Clean bytes beat noisy bytes, and more clean bytes beat fewer. A rate that
+// produced only framing errors is still kept if nothing better turns up: it
+// says "something is transmitting", which is the difference between a silent
+// bus and a dead part, even when the rate is wrong.
+static bool listen_is_better(const UartListenResult* candidate, const UartListenResult* best) {
+    bool candidate_clean = candidate->bytes > 0 && candidate->frame_errors == 0;
+    bool best_clean = best->bytes > 0 && best->frame_errors == 0;
+    if(candidate_clean != best_clean) return candidate_clean;
+    return candidate->bytes > best->bytes;
+}
+
+// The whole sweep inside one acquire. Changing rate is what set_br is for, and
+// re-acquiring per rate would mean four more chances to leak the handle and
+// four more rounds of shutting the expansion service down and bringing it back.
+static bool uart_listen_body(FuriHalSerialHandle* handle, UartRxContext* rx, void* context) {
+    ListenJob* job = context;
+
+    for(size_t i = 0; i < job->baud_count; i++) {
+        uint32_t baud = job->bauds[i];
+        if(!furi_hal_serial_is_baud_rate_supported(handle, baud)) continue;
+
+        // Quiet the receiver while the peripheral is reconfigured, then start
+        // from an empty buffer and a zero error count so each rate is judged on
+        // what arrived at that rate alone.
+        furi_hal_serial_async_rx_stop(handle);
+        furi_hal_serial_set_br(handle, baud);
+        furi_stream_buffer_reset(rx->rx);
+        rx->frame_errors = 0;
+        furi_hal_serial_async_rx_start(handle, uart_rx_callback, rx, true);
+
+        bool completed = listen_wait(job->window_ms, job->abort);
+
+        uint8_t buffer[UART_RX_BUFFER];
+        size_t got = furi_stream_buffer_receive(rx->rx, buffer, sizeof(buffer), 0);
+
+        UartListenResult result = {
+            .baud = baud,
+            .bytes = got,
+            .frame_errors = rx->frame_errors,
+            .sample_len = got < UART_LISTEN_MAX_SAMPLE ? got : UART_LISTEN_MAX_SAMPLE,
+        };
+        memcpy(result.sample, buffer, result.sample_len);
+
+        if(got || result.frame_errors) {
+            if(!job->found || listen_is_better(&result, &job->best)) {
+                job->best = result;
+                job->found = true;
+            }
+        }
+        if(!completed) break; // asked to stop; what was heard is still kept
+    }
+    return job->found;
+}
+
+UartListenOutcome uart_listen_sweep(
+    const uint32_t* bauds,
+    size_t baud_count,
+    uint32_t window_ms,
+    const volatile bool* abort,
+    UartListenResult* out) {
+    furi_check(out);
+    memset(out, 0, sizeof(*out));
+    if(!bauds || !baud_count) return UartListenUnavailable;
+
+    ListenJob job = {
+        .bauds = bauds,
+        .baud_count = baud_count,
+        .window_ms = window_ms,
+        .abort = abort,
+    };
+    bool ran = false;
+    bool heard = uart_with_lpuart(bauds[0], uart_listen_body, &job, &ran);
+    if(!ran) return UartListenUnavailable;
+    if(!heard) return UartListenSilent;
+
+    *out = job.best;
+    return UartListenHeard;
+}
+
+/* ---- loopback self-test ---- */
+
+// Deliberately not 0x00 or 0xFF: a stuck line reads as one of those, and a test
+// that passes on a stuck line is worse than no test. Mixed bit patterns also
+// exercise framing rather than a run of identical edges.
+static const uint8_t uart_selftest_pattern[] = {0x55, 0xAA, 0x0F, 0xF0, 0x3C, 0xC3};
+
+// The buffer travels with its size instead of as a bare pointer. The size used
+// to live here as a literal 32 that had to keep agreeing with a declaration in
+// another function, and that is the kind of agreement that stops being true
+// quietly.
+typedef struct {
+    char* text;
+    size_t size;
+} SelftestDetail;
+
+static bool uart_selftest_body(FuriHalSerialHandle* handle, UartRxContext* rx, void* context) {
+    SelftestDetail* detail = context;
+
+    furi_hal_serial_tx(handle, uart_selftest_pattern, sizeof(uart_selftest_pattern));
+    furi_hal_serial_tx_wait_complete(handle);
+    furi_delay_ms(50); // the last byte still has to arrive and be handled
+
+    uint8_t got[sizeof(uart_selftest_pattern) * 2] = {0};
+    size_t len = furi_stream_buffer_receive(rx->rx, got, sizeof(got), 0);
+
+    bool ok = len == sizeof(uart_selftest_pattern) &&
+              memcmp(got, uart_selftest_pattern, len) == 0 && rx->frame_errors == 0;
+
+    if(detail && detail->text && detail->size) {
+        if(ok) {
+            snprintf(detail->text, detail->size, "%u bytes back, clean", (unsigned)len);
+        } else if(len == 0) {
+            snprintf(detail->text, detail->size, "nothing came back");
+        } else {
+            snprintf(
+                detail->text,
+                detail->size,
+                "%u bytes, %lu errors",
+                (unsigned)len,
+                rx->frame_errors);
+        }
+    }
+    return ok;
+}
+
+bool uart_selftest_loopback(uint32_t baud, char* detail, size_t detail_size) {
+    // Written first and only overwritten if the body actually ran. Never
+    // reaching the wire has to read differently from reaching it and hearing
+    // nothing -- on this screen most of all, because it is the one place a
+    // user is told the transport itself is sound.
+    if(detail && detail_size) snprintf(detail, detail_size, "LPUART unavailable");
+    char line[40] = {0};
+    SelftestDetail sink = {.text = line, .size = sizeof(line)};
+    bool ok = uart_with_lpuart(baud, uart_selftest_body, &sink, NULL);
+    if(detail && detail_size && line[0]) snprintf(detail, detail_size, "%s", line);
+    return ok;
+}

--- a/non_catalog_apps/fake_chip_detector/uart_listen.h
+++ b/non_catalog_apps/fake_chip_detector/uart_listen.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+// LPUART on the same two header pins the I2C bus uses: PC1 is pin 15 and PC0 is
+// pin 16, which is why any of this is possible on four wires. Nothing has to be
+// re-plugged to go from scanning I2C to listening on a serial line -- and a
+// sensor strapped into UART mode puts its Tx on the pad silkscreened SCL, which
+// is already sitting in pin 16.
+//
+// Everything here blocks and is meant to be called from a worker thread, never
+// from a draw or input callback.
+
+#define UART_LISTEN_MAX_SAMPLE 32
+
+typedef struct {
+    uint32_t baud; // the rate this result was gathered at
+    size_t bytes; // how many arrived inside the window
+    uint32_t frame_errors; // wrong-rate traffic shows up here, not as bytes
+    uint8_t sample[UART_LISTEN_MAX_SAMPLE]; // the first bytes, for the report
+    size_t sample_len;
+} UartListenResult;
+
+// Three outcomes, not two, and the third is the reason this is an enum. A
+// caller handed a plain false cannot tell "listened and heard nothing" from
+// "never got to listen", and will eventually print the first while meaning the
+// second -- which is the app claiming a measurement it did not make, about the
+// one screen a user reaches when they are already being told bad news.
+// "Nothing established" is the zero value on purpose, the same way I2CPadUnknown
+// is: a zeroed variable, or a caller who forgets to look, then defaults to the
+// answer that claims the least.
+typedef enum {
+    UartListenUnavailable, // never listened: LPUART busy, or not on PC0/PC1
+    UartListenSilent, // the sweep ran and every rate came back empty
+    UartListenHeard, // something was transmitting; the result is filled in
+} UartListenOutcome;
+
+// Why the sweep and not one guess: the rate is not knowable in advance, and a
+// wrong one turns real traffic into framing errors rather than silence. The
+// winner is the rate that produced bytes *without* them.
+//
+// abort may be NULL. When it is not, the sweep gives up promptly once it turns
+// true, keeping whatever it had heard by then. This exists because the caller
+// is a worker thread that gets joined on the way out of the app: a wait that
+// ignored the flag would show up to the user as the app taking two seconds to
+// close.
+UartListenOutcome uart_listen_sweep(
+    const uint32_t* bauds,
+    size_t baud_count,
+    uint32_t window_ms,
+    const volatile bool* abort,
+    UartListenResult* out);
+
+// Loopback self-test: with a jumper from pin 15 to pin 16 this proves the whole
+// path -- expansion service stood down, handle acquired, pinout as documented,
+// framing, transmit, the interrupt-context receive, and a clean release. It is
+// the only way to test the transport without owning a UART sensor, and it uses
+// one wire the user already has.
+//
+// detail receives a short human-readable line either way; pass NULL to skip.
+bool uart_selftest_loopback(uint32_t baud, char* detail, size_t detail_size);


### PR DESCRIPTION
Fake Chip Detector 0.11. `non_catalog_apps/fake_chip_detector/` re-copied from
[master](https://github.com/hleserg/flipper-fake-chip-detector). The pack has not been updated
since 0.7, so this carries 0.8 through 0.11 together.

**0.11 corrects the live test 0.10 added, in two places.** It read and redrew as fast as I²C
would carry it, where the part produces a new sample ten times a second — so it now waits a
sample period between reads instead of republishing the frame already on screen. And it
establishes its mode with the datasheet's Suspend Mode rather than a soft reset the datasheet
gives no settling time for anywhere.

**A GY-271 board reading QMC5883P no longer looks like a contradiction (0.10).** The number
silkscreened on a module and the number burned into the die are different things — that is the
whole premise of the app — and the one screen that asks **Is this what you bought?** was the one
screen that never said so. The database has carried a note field since the first release, but
the note was only drawn on the detail screen behind the question. It is on the question screen
now, above the verdict, for every chip that has one. The QMC5883P has one: **GY-271 board, not a
5883L**. GY-271 is the module name the HMC5883L made famous; the die inside one bought today is
usually a QST part, and a P is not register-compatible with either the HMC5883L or the QMC5883L.

**The QMC5883P has met a part, and has a live test (0.10).** Added in 0.8 from a datasheet with
nothing to answer it; on 9 Sep 2026 a blue GY-271 answered at 0x2C and read `0x80` at register
`0x00`. Its live test fires the internal self-test coil, checks that all three channels deflect,
then asks the earth's field to move by 300 counts on two axes while the board is turned. Every
constant cites QST document 13-52-19 Rev. C with section and page; the one number QST does not
publish is the self-test threshold, so the test uses three sigma of the published noise figure
as a floor and says in the source that it is a floor. Fifteen live tests now.

**The AK09911 live test could not pass, and now it does (0.9).** It asked the field to swing 100
counts on two axes. The earth puts about 50 counts into the whole vector, so no single axis can
swing further than twice that. A real part proved it: 1545 reads, swings plateaued at 38/47/26,
the counter never left 0/2; stationary noise was 4/5/7. The threshold is 30 now and the test
passes in about ten seconds. Three lines of that screen were also being published into a screen
with room for two, so the instruction, the saturation advice and the "left running" warning were
all silently dropped.

**The app no longer names a chip the bus never identified (0.8).** The identifier picked the
first row in its database that fit and printed it as a name. Six addresses host two or more
chips with no ID register, and 0x18 holds two whose ID checks both pass — a BMI088 accelerometer
and a LIS3DH — so those were being resolved by table order, silently. There is now a **SEVERAL
POSSIBLE** verdict that names every candidate instead, grouped with the good verdicts on
purpose: it says the tool cannot tell two real parts apart, which is a limit of two wires and
not an accusation against the chip.

**Two new magnetometers (0.8)** — AK09911 and QMC5883P, 82 chips. The AK09911 answers nothing at
all while its reset pad is held low, so the silent-bus screen names `RST` alongside `XSHUT`,
`RES` and `EN`.

Also included, since the pack has not been updated since 0.7: a UART self-test screen, an
automatic LPUART listen after an empty sweep, bare SDA-to-SCL short detection, and the chip
`kind` renames.

Honest note: three of the fifteen live tests have been driven end to end on real silicon — the
VL6180X, the AK09911 and the QMC5883P. The other twelve have never met the chip they were
written for. The QMC5883P test has passed twice on a GY-271 board, most recently on 0.11, where
the field read 27 µT — inside the earth's 25 to 65. What is still unproven is the thresholds
under it: both derived rather than measured, and the still part's noise floor never recorded.
All of it is in the repository's `BACKLOG.md`.

The `ReadMe.md` catalog cell moved from `![None Badge]` to the lab link in the 0.8 commit — the
app went live at [lab.flipper.net/apps/fake_chip_detector](https://lab.flipper.net/apps/fake_chip_detector)
after the 0.7 catalog submission was merged. Revert that line if you would rather set it yourself.

Builds clean against unleashed (API 88.4), official (87.1) and momentum (87.1) — all three are
built on every pull request in the source repository's CI.
