### PR TITLE
Update Fake Chip Detector to 0.13

### DIFF
--- a/non_catalog_apps/fake_chip_detector/CHANGELOG.md
+++ b/non_catalog_apps/fake_chip_detector/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.13 — beta
+
+- **Two drawing fixes from xMasterX**, found running the app on a Flipper with nothing wired to
+  the I2C pins and sent as a patch on the Apps Catalog pull request. The Right-key glyph on the
+  save log, details and find out bars spans seven rows around the y it is given, so the y it was
+  drawn at put its last row one below the bottom of a 64-row screen and cut the tip off the
+  arrow. And on the pad meter the title and the key hint were drawn at the same height from
+  opposite edges with nothing checking they fit, so **Pad reads FLOATING** ran straight through
+  **save**. The hint is drawn first now and the title fitted to the room left over, so no title
+  can overlap it again — and the titles are shorter, which means none of them has to be.
+
+## 0.12 — beta
+
+- **The QMC5883L has a live test now.** It is the die a GY-271 board most often carries, and the
+  one this app could identify and then say nothing more about. The test asks the field to move by
+  240 counts on two different axes while the board is turned, and that is its only claim. There is
+  no self-test half, because this part has no self-test: its second control register holds a soft
+  reset, a pointer-roll bit and an interrupt enable and nothing else, so there is no coil to fire
+  on command. The threshold is arithmetic off the datasheet's sensitivity figure — sixteen per
+  cent of what turning a board end over end reaches at the weakest place on earth, and forty times
+  the noise its own resolution figure implies — and it has never been compared against a still
+  part. No QMC5883L has been on the bench at all: the board that prompted the work carries a P.
+  Sixteen live tests now, thirteen of which have never met the chip they were written for.
+
+## 0.11 — beta
+
+- **The QMC5883P live test now waits for the part instead of racing it.** Its measurement loop
+  read and redrew as fast as the I2C bus would go. The part produces a new sample ten times a
+  second and no faster, so most of those reads returned the number already on the screen, and
+  every one of them was published again — which drove the display, and anything watching the
+  screen over USB, at a rate nothing needed. It now waits a sample period between reads.
+- **And it establishes the mode with Suspend rather than a soft reset.** 0.10 put a soft reset
+  in front of each configuration to stop the part carrying state from one run into the next.
+  That was the right idea and the wrong instruction: the datasheet gives no settling time for a
+  soft reset anywhere, so a configuration written straight after one is written into a part that
+  may still be resetting. Suspend Mode is what the datasheet actually asks for in the middle of a
+  mode shift, it is one write, and it needs no guess about timing.
+
 ## 0.10 — beta
 
 - **A GY-271 board reading QMC5883P no longer looks like a contradiction.** The number
@@ -13,6 +51,19 @@
   HMC5883L made famous and the number people still search for. The die inside one bought today is
   usually a QST part, and a P is not register-compatible with either the HMC5883L or the
   QMC5883L, so a driver written for the name on the silkscreen will not talk to it.
+- **The QMC5883P has a live test now.** It fires the part's internal self-test coil and checks
+  that all three channels deflect, then asks the field to move by 300 counts on two different
+  axes while the board is turned. The coil half is deliberately a floor rather than a
+  specification: QST's datasheet says to compare the deflection with a threshold value and then
+  publishes no threshold anywhere, so the test checks that a deflection happened at all, by a
+  margin three times the part's own documented noise. A GY-271 board passed it on 9 Sep 2026 —
+  1036 reads, the coil fired, the field followed the board — which makes the thresholds
+  reachable but not measured: the movement threshold is still arithmetic off the datasheet's
+  sensitivity figure, and the lesson from the AK09911 is that a threshold means nothing until
+  the still part's noise floor is measured under it. A second run on the same board exposed two
+  faults, both fixed here: the self-test was waiting on a data-ready flag the part stops
+  producing when the self-test ends, and the measurement was configured on top of whatever the
+  previous run had left rather than from a soft reset.
 - **The QMC5883P row has met a part.** It was added in 0.8 from its datasheet with nothing to
   answer it. On 9 Sep 2026 a blue GY-271 board answered at 0x2C and read 0x80 at register 0x00,
   which is that row and no other.

--- a/non_catalog_apps/fake_chip_detector/LIVE_TESTS.md
+++ b/non_catalog_apps/fake_chip_detector/LIVE_TESTS.md
@@ -33,7 +33,7 @@ which of the two they are looking at.
 Tests do not have to be built into the app. A test can be shipped as a single `.fal` file, and
 the app will find it, list it and run it — no rebuild, no reflash.
 
-1. Get the `.fal`. Build it yourself from [`test_plugin_template/`](../test_plugin_template), or
+1. Get the `.fal`. Build it yourself from [`test_plugin_template/`](https://github.com/hleserg/flipper-fake-chip-detector/tree/master/test_plugin_template), or
    take one somebody published.
 2. Open **Live tests** once. The app creates the folder it looks in, which saves you guessing at
    the spelling.
@@ -232,6 +232,31 @@ tick when it is reached. Pick something the part cannot fake by holding still:
   choosing a movement threshold for a magnetometer, measure the still part first: the noise
   floor is the half that says whether the number means anything.
 
+- **QMC5883P** — the internal self-test coil deflects all three channels by more than the
+  part's own published noise, **and** the field afterwards moves by 300 counts on two different
+  axes at the ±8 G range. The coil half is deliberately a floor and not a specification: QST
+  says to "compare with threshold value" and then publishes no threshold anywhere in the
+  datasheet, so this checks that a deflection happened at all, by a margin three times the
+  documented standard deviation. Three hundred is arithmetic, not measurement — the earth is
+  0.25 to 0.65 G, which is 937 counts at the weakest place on earth and 1875 of swing when a
+  board is turned end over end — and it has never been compared against a still part. Do that
+  before trusting it. A GY-271 board passed this test on 9 Sep 2026, which makes the numbers
+  reachable but says nothing about how much room is under them.
+
+- **QMC5883L** — the field moves by 240 counts on two different axes at the ±8 G range, and
+  that is the whole test. There is no coil half here and there cannot be: this part's control
+  register 2 holds a soft reset, a pointer-roll bit and an interrupt enable, and nothing else,
+  so it has no self-test to fire. One honest claim is what the silicon supports. Two hundred
+  and forty is the QMC5883P's 300 rescaled to this part's 3000 LSB/G, which is sixteen per cent
+  of the 1500-count ceiling a board turned end over end reaches at the weakest place on earth,
+  and forty times the 6 counts its datasheet's 2 mGauss resolution figure implies. Like the
+  QMC5883P's, it is arithmetic rather than measurement, and no QMC5883L has been on the bench
+  at all. It does insist on at least eight readings before it will pass, which the QMC5883P test
+  does not: that one once passed on silicon after two, and two readings is few enough that a
+  sensor reconnecting mid-test could have supplied the whole swing on its own. The P has a coil
+  firing underneath it and this one has nothing but the movement, so the movement has to come
+  from a run of readings.
+
 Two of these are worth copying for the shape rather than the numbers. The BH1750 test insists
 on **both directions**, which is what stops a dead part passing by accident. The accelerometer
 tests pass on a **change of which axis** holds gravity rather than on any absolute value, so
@@ -300,7 +325,7 @@ A test does not have to be merged here to be useful. Built as a `.fal` and copie
 it appears in the browser and runs like any other — no rebuild of the app, no pull request, no
 waiting for anyone.
 
-Start from [`test_plugin_template/`](../test_plugin_template) in the repository root. It is a
+Start from [`test_plugin_template/`](https://github.com/hleserg/flipper-fake-chip-detector/tree/master/test_plugin_template) in the upstream repository. It is a
 complete working test, not a snippet: copy the folder, change the registers, the pass condition
 and the strings, then
 

--- a/non_catalog_apps/fake_chip_detector/README.md
+++ b/non_catalog_apps/fake_chip_detector/README.md
@@ -1,14 +1,43 @@
 # Fake Chip Detector
 
-The app itself. Everything about what it does, how to wire a module to it and how to install it
-lives in the repository README, one directory up: **[../README.md](../README.md)**.
+Tells you whether an I²C sensor really is the chip it was sold as — before you solder it in.
 
-In this directory:
+Modules sold as a BME280 frequently carry a BMP280 die. "MPU9250" boards often contain an
+MPU6500 with no magnetometer in it. Plug the module into the GPIO header, scan, and the app
+reads the chip's factory ID register — the number burned into the die rather than printed on the
+package — names the part, and then asks the one question it cannot answer itself: is this what
+you bought?
 
-- **[SUPPORTED_CHIPS.md](SUPPORTED_CHIPS.md)** — every chip in the database, with the register
-  and expected value used to identify each one. Generated from `chip_db.c`; do not hand-edit.
-- **[LIVE_TESTS.md](LIVE_TESTS.md)** — how a live test works, how to run one from the SD card,
-  how to write your own, and where to send it when it works.
-- **[docs/changelog.md](docs/changelog.md)** — what shipped.
+- **82 chips** in the database, 53 identified by an ID register and 29 by address alone. Every
+  constant is taken from the manufacturer's datasheet and cited in `chip_db.c`.
+- **A report** written for a seller: plain statement first, why a factory ID cannot be forged
+  second, register values last. Readable on the device, saved to
+  `/ext/apps_data/fake_chip_detector/`.
+- **Wiring diagnosis** with live per-line detection — missing pull-up, line shorted to ground,
+  SDA shorted to SCL, or the module plugged into the wrong header pins entirely.
+- **16 live tests.** An ID register is one byte and a byte can be copied; a working sensor
+  cannot. Breathe on an AHT or SHT, cover a BH1750, tip an MPU6050 or ADXL345, wave at an
+  APDS9960, point an MLX90614 at your palm, watch a DS3231 tick, blink an SSD1306, turn a BNO055
+  through a figure-8, turn an AK09911, a QMC5883L or a QMC5883P over and watch the earth's
+  field follow it, hold a hand in front of a VL6180X.
+- **1-Wire scanning** on pin 17 with a real temperature conversion, so a DS18S20 sold as a
+  DS18B20 is caught.
+- Tests can also be **loaded from the SD card as .fal plugins** — see [LIVE_TESTS.md](LIVE_TESTS.md).
 
-Build with `ufbt` from this directory — it is the one that holds `application.fam`.
+It refuses to overclaim: a chip with no ID register is reported as present, never as genuine; a
+device matching nothing is unidentified, not "fake"; a failed read is shown as a failure; and
+when more than one part fits what was read, it names them all rather than picking one.
+
+## Wiring
+
+Pin 8 → GND, pin 9 → 3V3, pin 15 → SDA, pin 16 → SCL. **Ground first, signals last.** The GPIO
+pins are 3.3 V and not 5 V tolerant.
+
+## Elsewhere
+
+Source, a beginner's guide with screenshots, and releases for all three firmwares:
+[github.com/hleserg/flipper-fake-chip-detector](https://github.com/hleserg/flipper-fake-chip-detector)
+
+Full chip list: [SUPPORTED_CHIPS.md](SUPPORTED_CHIPS.md).
+
+MIT licensed.

--- a/non_catalog_apps/fake_chip_detector/SUPPORTED_CHIPS.md
+++ b/non_catalog_apps/fake_chip_detector/SUPPORTED_CHIPS.md
@@ -60,8 +60,8 @@ label claims.
 | **LIS2MDL** | Magnetometer | 0x1E | `0x4F` | `0x40` | 8-bit | — |  |
 | **MMC5603** | Magnetometer | 0x30 | `0x39` | `0x10` | 8-bit | — |  |
 | **HMC5883L** | Magnetometer | 0x1E | `0x0A`<br>`0x0B`<br>`0x0C` | `0x48`<br>`0x34`<br>`0x33` | 8-bit<br>8-bit<br>8-bit | — | EOL since 2016, mostly fake |
-| **QMC5883L** | Magnetometer | 0x0D | `0x0D` | `0xFF` | 8-bit | — |  |
-| **QMC5883P** | Magnetometer | 0x2C | `0x00` | `0x80` | 8-bit | — | GY-271 board, not a 5883L |
+| **QMC5883L** | Magnetometer | 0x0D | `0x0D` | `0xFF` | 8-bit | Turn it through a field |  |
+| **QMC5883P** | Magnetometer | 0x2C | `0x00` | `0x80` | 8-bit | Turn it through a field | GY-271 board, not a 5883L |
 | **AK09911** | Magnetometer | 0x0C, 0x0D | `0x00`<br>`0x01` | `0x48`<br>`0x05` | 8-bit<br>8-bit | Wave it through a field | RST must be high to answer |
 | **VL53L0X** | Laser rangefinder | 0x29 | `0xC0` | `0xEE` | 8-bit | — |  |
 | **VL53L1X** | Laser rangefinder | 0x29 | `0x010F` MODEL_ID<br>`0x0110` MODULE_TYPE | `0xEA`<br>`0xCC` | 8-bit<br>8-bit | — |  |

--- a/non_catalog_apps/fake_chip_detector/application.fam
+++ b/non_catalog_apps/fake_chip_detector/application.fam
@@ -7,7 +7,7 @@ App(
     stack_size=4 * 1024,
     fap_icon="icons/fake_chip_detector_10px.png",
     fap_category="GPIO",
-    fap_version="0.10",
+    fap_version="0.13",
     fap_author="hleserg",
     fap_description="Check whether an I2C sensor really is the chip it was sold as, before you solder it in.",
 )

--- a/non_catalog_apps/fake_chip_detector/live_qmc5883l.c
+++ b/non_catalog_apps/fake_chip_detector/live_qmc5883l.c
@@ -1,0 +1,389 @@
+#include "live_qmc5883l.h"
+
+#include <furi.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+
+// QST QMC5883L, a 3-axis magnetometer. Every constant below is quoted from the
+// QMC5883L datasheet, QST document 13-52-04, QST-PD-B002-22, Rev. B, with the
+// section and page named at each one.
+//
+// This is the third of the three dies a board silkscreened GY-271 can carry,
+// and the one it usually does. The other two already have somewhere to go: the
+// QMC5883P sits at 0x2C and has live_qmc5883p.c next to this file, and the
+// Honeywell HMC5883L sits at 0x1E and has been out of production since 2016.
+// This part answers at 0x0D, which is also where an AK09911 answers -- so the
+// chip ID is doing real work here, not ceremony.
+//
+// The important difference from the P, and the reason this file is shorter:
+// the QMC5883L has no self-test. Its control register 2 holds SOFT_RST,
+// ROL_PNT and INT_ENB and nothing else (Rev. B section 9.2.4, page 19), so
+// there is no internal coil to fire and no way to make the part deflect its
+// own channels on command. That leaves one honest proof, and this test makes
+// exactly one claim: the field this part reports follows the board through the
+// earth's. A canned register cannot do that. A dead channel cannot do that.
+// What it does not prove is anything about the signal chain that a still part
+// could also satisfy, and the screen does not pretend otherwise.
+//
+// NOT RUN ON HARDWARE. The sequences are the datasheet's own worked examples
+// and it compiles, but no QMC5883L has been on the bench -- the board that
+// prompted this work carries a P. See BACKLOG.md.
+
+// Rev. B section 9.2.6 and Table 19, page 20: "This register is chip
+// identification register. It returns 0xFF."
+//
+// That is the weakest possible signature -- 0xFF is also what an idle bus
+// looks like -- which is why it is read through live_test_read_id8, twice,
+// with the two required to agree, and why nothing is written until they do. It
+// is still evidence: a bus with pull-ups and no device at this address NACKs
+// rather than answering 0xFF, and the other part that lives at 0x0D, the
+// AK09911, answers 0x48 there.
+#define QMCL_REG_CHIPID 0x0D
+#define QMCL_CHIPID     0xFF
+
+// Rev. B Table 12 and Table 13, pages 18: 00H..05H are X/Y/Z as LSB then MSB,
+// "Each axis has 16 bit data width in 2's complement". Read as one six-byte
+// burst.
+#define QMCL_REG_XOUT_LSB 0x00
+#define QMCL_DATA_LEN     6
+
+// Rev. B section 9.2.2 and Table 14, pages 18 and 19: status register 06H, bit
+// 0 DRDY "0: no new data, 1: new data is ready", bit 1 OVL "set to 1 if any
+// data of three axis magnetic sensor channels is out of range", bit 2 DOR
+// "set to 1 if all the channels of output data registers are skipped in
+// reading".
+//
+// DRDY and DOR are "reset to 0 by reading any data register (00H~05H)" -- not
+// by reading the status register, which is the opposite of the QMC5883P and
+// the reason this loop reads status and data in that order without having to
+// carry the flags out. OVL is different again: it "is reset to 0 if next
+// measurement goes back to the range", so it clears itself when the magnet
+// goes away and never needs acknowledging.
+#define QMCL_REG_STATUS 0x06
+#define QMCL_ST_DRDY    0x01
+#define QMCL_ST_OVL     0x02
+
+// Rev. B Table 12, page 18, and section 9.2.4, page 19. Control register 1 at
+// 09H holds OSR<7:6>, RNG<5:4>, ODR<3:2> and MODE<1:0>; control register 2 at
+// 0AH holds SOFT_RST<7>, ROL_PNT<6> and INT_ENB<0>; 0BH is the SET/RESET
+// period FBR.
+#define QMCL_REG_CTRL1 0x09
+#define QMCL_REG_CTRL2 0x0A
+#define QMCL_REG_FBR   0x0B
+
+// The datasheet's own worked examples, quoted whole rather than assembled from
+// bit fields -- a byte the manufacturer has written down and a byte that
+// happens to have the right bits in it are not the same kind of evidence.
+//
+// Rev. B section 7.1, page 15, "Continuous Mode Setup Example":
+//   (1) Write Register 0BH by 0x01 (Define Set/Reset period)
+//   (2) Write Register 09H by 0x1D (Define OSR = 512, Full Scale Range = 8
+//       Gauss, ODR = 200Hz, set continuous measurement mode)
+#define QMCL_FBR_VALUE     0x01
+#define QMCL_CTRL1_CONT    0x1D
+// Rev. B section 7.3, page 15, "Standby Example: Write Register 09H by 0x00".
+#define QMCL_CTRL1_STANDBY 0x00
+// Rev. B section 7.4, page 15, "Soft Reset Example: Write Register 0AH by
+// 0x80", and section 9.2.4: "Soft reset can be invoked at any time of any
+// mode... restore default value of all registers". One write undoes both
+// control registers, the set/reset period and the mode, which is why parking
+// this part needs no bookkeeping about what was changed.
+#define QMCL_CTRL2_SOFTRST 0x80
+
+// Rev. B Table 2, page 8: sensitivity is 12000 LSB/G at the +/-2 G range and
+// 3000 LSB/G at +/-8 G. The example above selects +/-8 G, so that is the
+// divisor every number on this screen goes through.
+#define QMCL_LSB_PER_G 3000
+
+// One gauss is a hundred microtesla, and microtesla is what the heading shows:
+// the earth reads about 50 of them, which is a number somebody can sanity-check
+// against the QMC5883P test on the same bench.
+#define QMCL_UT_PER_G 100.0f
+
+// The earth's field is 0.25 to 0.65 gauss depending on where you stand. At
+// 3000 LSB/G that is 750 counts at the weakest place on earth, and turning a
+// board exactly end over end swings one axis by twice the component along it --
+// so 1500 counts is the worst-case ceiling, not the expectation. Two hundred
+// and forty is sixteen per cent of that ceiling.
+//
+// Rev. B Table 2, page 8, "Field Resolution, Standard deviation 100 Data, FS
+// +/-2G": 2 mGauss. That is quoted at the other range, but 2 mGauss is 6 counts
+// at this one, so the threshold is forty times the part's own published noise
+// either way.
+//
+// ponytail: derived from the datasheet rather than measured, which is exactly
+// the footing that made the AK09911 threshold wrong the first time. Measure a
+// still part before trusting it; BACKLOG.md says so too.
+#define QMCL_MOVE_COUNTS 240
+#define QMCL_MOVE_AXES   2
+
+// And a floor under how few samples a pass may be built from. The QMC5883P
+// test has none, and on silicon it once passed after two reads -- which is few
+// enough that a sensor reconnecting mid-test could have supplied the whole
+// swing by itself, with no field and no hand involved. That test has a coil
+// firing underneath it; this one has nothing but the movement, so the movement
+// has to come from a run of readings rather than from a pair. Eight of them at
+// a sample period each is under a second of turning.
+#define QMCL_MIN_SAMPLES 8
+
+// Rev. B Table 16, page 19: ODR is bits 3:2 of the byte section 7.1 writes to
+// 09H, and 0x1D selects 200 Hz. Polling at 20 ms therefore always finds a
+// sample waiting, and 500 ms of nothing means the part has stopped rather than
+// that it is slow.
+#define QMCL_POLL_MS           20
+#define QMCL_SAMPLE_TIMEOUT_MS 500
+
+// And this is why the loop does not read at 200 Hz just because it could. A
+// hand cannot turn a board faster than a few times a second, the screen cannot
+// show more, and publishing a frame per sample drives the display -- and
+// anything watching it over USB -- at a rate nothing asked for. The QMC5883P
+// test shipped without this and flooded its own screen stream until USB writes
+// timed out. Sampling every hundred milliseconds deliberately skips data,
+// which is what the DOR flag exists to announce, so DOR is not read here and
+// not reported: it would be reporting this test's own choice back to the user
+// as a fault.
+#define QMCL_SAMPLE_PERIOD_MS 100
+
+typedef struct {
+    int32_t min;
+    int32_t max;
+} QmclAxisRange;
+
+typedef enum {
+    QmclSampleOk,
+    QmclSampleOverflow, // an axis is out of range: not a small reading, not a reading
+    QmclSampleFailed, // the bus failed, or nothing became ready in time
+} QmclSampleResult;
+
+static void qmcl_delay(const volatile bool* stop, uint32_t ms) {
+    while(ms && !*stop) {
+        uint32_t chunk = ms > 40 ? 40 : ms;
+        furi_delay_ms(chunk);
+        ms -= chunk;
+    }
+}
+
+static LiveTestIdResult qmcl_identify(const LiveTestI2c* i2c, uint8_t addr7) {
+    uint8_t id = 0;
+    if(!live_test_read_id8(i2c, addr7, QMCL_REG_CHIPID, &id))
+        return live_test_id_unreadable(i2c, addr7);
+    return id == QMCL_CHIPID ? LiveTestIdMatch : LiveTestIdMismatch;
+}
+
+// One measurement: section 7.2's two steps, page 15 -- "Check status register
+// 06H[0], 1 means ready" and "Read data register 00H ~ 05H".
+//
+// An overflowed sample is reported as such and its bytes are never returned.
+// Printing them would be printing a number the part did not stand behind, and
+// past the saturation point the axis has run out of range rather than measured
+// anything.
+static QmclSampleResult qmcl_read_sample(
+    const LiveTestI2c* i2c,
+    uint8_t addr7,
+    const volatile bool* stop,
+    int32_t out[3]) {
+    for(uint32_t waited = 0; waited < QMCL_SAMPLE_TIMEOUT_MS && !*stop; waited += QMCL_POLL_MS) {
+        uint8_t status = 0;
+        if(!i2c->read_reg(addr7, QMCL_REG_STATUS, &status, LIVE_TEST_TIMEOUT_MS))
+            return QmclSampleFailed;
+
+        if(!(status & QMCL_ST_DRDY)) {
+            qmcl_delay(stop, QMCL_POLL_MS);
+            continue;
+        }
+        if(status & QMCL_ST_OVL) return QmclSampleOverflow;
+
+        uint8_t buf[QMCL_DATA_LEN] = {0};
+        if(!i2c->read_mem(addr7, QMCL_REG_XOUT_LSB, buf, sizeof(buf), LIVE_TEST_TIMEOUT_MS))
+            return QmclSampleFailed;
+
+        for(uint8_t axis = 0; axis < 3; axis++) {
+            // LSB register first, then MSB -- Table 13. Getting this backwards
+            // produces numbers that look entirely plausible and are not.
+            out[axis] = (int16_t)((uint16_t)buf[axis * 2] | ((uint16_t)buf[axis * 2 + 1] << 8));
+        }
+        return QmclSampleOk;
+    }
+    return QmclSampleFailed;
+}
+
+static void qmcl_run(const LiveTestEnv* env) {
+    const uint8_t addr7 = env->addr7;
+    const volatile bool* stop = env->stop;
+    const LiveTestI2c* i2c = env->i2c;
+    const LiveTestPublish publish = env->publish;
+    void* const ctx = env->ctx;
+
+    while(!*stop) {
+        LiveTestState st;
+        memset(&st, 0, sizeof(st));
+        st.phase = LiveTestPhaseStarting;
+        snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Reading the chip ID");
+        publish(ctx, &st);
+
+        const LiveTestIdResult id_seen = qmcl_identify(i2c, addr7);
+        if(id_seen != LiveTestIdMatch) {
+            memset(&st, 0, sizeof(st));
+            st.phase = id_seen == LiveTestIdMismatch ? LiveTestPhaseWrongChip : LiveTestPhaseLost;
+            if(id_seen == LiveTestIdMismatch) {
+                // 0x0D is shared. An AK09911 answers here too, and so does a
+                // GY-271 whose die is something this app has never met.
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "0x%02X answers, but not", addr7);
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "the way a QMC5883L does.");
+            } else {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It replied, then stopped.");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Check 3V3 and the wires.");
+            }
+            publish(ctx, &st);
+            qmcl_delay(
+                stop,
+                id_seen == LiveTestIdMismatch ? LIVE_TEST_WRONG_CHIP_RETRY_MS :
+                                                LIVE_TEST_RETRY_MS);
+            continue;
+        }
+
+        // Identified. From here every path has written something, so every path
+        // out of this loop body soft-resets the part -- including the ones where
+        // a write was not acknowledged, because a write that was not
+        // acknowledged may still have landed.
+
+        memset(&st, 0, sizeof(st));
+        st.phase = LiveTestPhaseStarting;
+        st.progress_max = QMCL_MOVE_AXES;
+        snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Starting the magnetometer");
+        publish(ctx, &st);
+
+        // Section 7.3's Standby first, so the configuration below is written
+        // into a mode this test established rather than into whatever the last
+        // pass left behind. Section 9.2.4 says there is "no any restriction in
+        // the transferring between the modes", so this is not required the way
+        // the QMC5883P's is -- it is one write, and it makes the next two mean
+        // the same thing on the second run as on the first.
+        //
+        // Then section 7.1's example, both writes, in its order.
+        const bool measuring =
+            i2c->write_reg(addr7, QMCL_REG_CTRL1, QMCL_CTRL1_STANDBY, LIVE_TEST_TIMEOUT_MS) &&
+            i2c->write_reg(addr7, QMCL_REG_FBR, QMCL_FBR_VALUE, LIVE_TEST_TIMEOUT_MS) &&
+            i2c->write_reg(addr7, QMCL_REG_CTRL1, QMCL_CTRL1_CONT, LIVE_TEST_TIMEOUT_MS);
+
+        QmclAxisRange range[3];
+        for(uint8_t axis = 0; axis < 3; axis++) {
+            range[axis] = (QmclAxisRange){.min = INT32_MAX, .max = INT32_MIN};
+        }
+        uint32_t samples = 0;
+        uint16_t overflows = 0;
+        uint8_t errors = 0;
+        bool passed = false;
+
+        while(measuring && !passed && !*stop && errors < 3) {
+            int32_t raw[3] = {0};
+            const QmclSampleResult got = qmcl_read_sample(i2c, addr7, stop, raw);
+            if(got == QmclSampleOverflow) {
+                // A magnet against the case. Not a fault and not an error
+                // budget item, but it does have to reach the screen: without a
+                // publish here the display would simply stop moving with no
+                // reason given.
+                overflows++;
+                memset(&st, 0, sizeof(st));
+                st.phase = LiveTestPhaseRunning;
+                st.progress_max = QMCL_MOVE_AXES;
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Too strong - back it off");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Saturated x%u", (unsigned)overflows);
+                publish(ctx, &st);
+                qmcl_delay(stop, QMCL_SAMPLE_PERIOD_MS);
+                continue;
+            }
+            if(got != QmclSampleOk) {
+                errors++;
+                continue;
+            }
+            errors = 0;
+            samples++;
+
+            uint8_t moved = 0;
+            for(uint8_t axis = 0; axis < 3; axis++) {
+                if(raw[axis] < range[axis].min) range[axis].min = raw[axis];
+                if(raw[axis] > range[axis].max) range[axis].max = raw[axis];
+                if(range[axis].max - range[axis].min >= QMCL_MOVE_COUNTS) moved++;
+            }
+            passed = moved >= QMCL_MOVE_AXES && samples >= QMCL_MIN_SAMPLES;
+            if(passed) break; // publish it after the part is parked, not before
+
+            const float field =
+                QMCL_UT_PER_G *
+                sqrtf((float)raw[0] * raw[0] + (float)raw[1] * raw[1] + (float)raw[2] * raw[2]) /
+                QMCL_LSB_PER_G;
+
+            memset(&st, 0, sizeof(st));
+            st.phase = LiveTestPhaseRunning;
+            st.value = field;
+            st.progress = moved;
+            st.progress_max = QMCL_MOVE_AXES;
+            snprintf(st.heading, sizeof(st.heading), "%u", (unsigned)field);
+            snprintf(st.unit, sizeof(st.unit), "uT");
+            // Two lines, because a heading and progress boxes leave room for
+            // exactly two. The boxes already say how many axes have moved, so
+            // line 0 is the instruction and line 1 is the evidence that the
+            // part is answering at all rather than showing one frozen frame.
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Turn it over slowly");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "%lu reads", (unsigned long)samples);
+            publish(ctx, &st);
+            qmcl_delay(stop, QMCL_SAMPLE_PERIOD_MS);
+        }
+
+        // --- Park it ----------------------------------------------------
+        // One write puts everything back: section 7.4's soft reset restores the
+        // default value of all registers, and section 9.2.4 adds that the part
+        // "immediately switches to standby mode due to mode register is reset
+        // to 00 in default". Done before anything is published so the pass
+        // chime lands after the last measurement rather than during one -- this
+        // is a magnetometer and the speaker is a centimetre away.
+        const bool parked =
+            i2c->write_reg(addr7, QMCL_REG_CTRL2, QMCL_CTRL2_SOFTRST, LIVE_TEST_TIMEOUT_MS);
+
+        if(*stop) break;
+
+        memset(&st, 0, sizeof(st));
+        st.progress_max = QMCL_MOVE_AXES;
+        if(passed) {
+            st.phase = LiveTestPhasePassed;
+            st.progress = QMCL_MOVE_AXES;
+            snprintf(st.heading, sizeof(st.heading), "%lu", (unsigned long)samples);
+            snprintf(st.unit, sizeof(st.unit), "reads");
+            if(parked) {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "The field followed you");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "on two axes.");
+            } else {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Passed, but the part was");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "left running. Repower.");
+            }
+            publish(ctx, &st);
+            // Nothing is being measured and nothing is configured; this is a
+            // plain wait for Back.
+            while(!*stop)
+                qmcl_delay(stop, QMCL_POLL_MS);
+            break;
+        }
+
+        st.phase = LiveTestPhaseLost;
+        if(!measuring) {
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It will not start");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "measuring. Check 3V3.");
+        } else {
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It stopped answering.");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Check 3V3 and the wires.");
+        }
+        publish(ctx, &st);
+        qmcl_delay(stop, LIVE_TEST_RETRY_MS);
+    }
+}
+
+const LiveTest live_test_qmc5883l = {
+    .chip = "QMC5883L",
+    .title = "QMC5883L test",
+    .offer = "Turn it through a field",
+    .addrs = {0x0D},
+    .run = qmcl_run,
+    .draw = NULL,
+};

--- a/non_catalog_apps/fake_chip_detector/live_qmc5883l.h
+++ b/non_catalog_apps/fake_chip_detector/live_qmc5883l.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "live_test.h"
+
+extern const LiveTest live_test_qmc5883l;

--- a/non_catalog_apps/fake_chip_detector/live_qmc5883p.c
+++ b/non_catalog_apps/fake_chip_detector/live_qmc5883p.c
@@ -1,0 +1,482 @@
+#include "live_qmc5883p.h"
+
+#include <furi.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+
+// QST QMC5883P, a 3-axis magnetometer. Every constant below is quoted from the
+// QMC5883P datasheet, QST document 13-52-19 Rev. C, with the section and page
+// named at each one. That document was obtained in full, which is the
+// difference between this file and live_ak09911.c next to it.
+//
+// The part is worth a test for a reason that has nothing to do with its
+// registers. GY-271 is the module name the Honeywell HMC5883L made famous, and
+// a GY-271 bought today usually has a QST die on it -- an L or, increasingly, a
+// P. The three are not register-compatible with each other. So the number
+// silkscreened on the board says almost nothing, the chip ID says which die is
+// there, and this test says whether that die does the job. On 9 Sep 2026 a blue
+// GY-271 on the bench answered at 0x2C and read 0x80 at register 0x00, which is
+// what prompted the file.
+//
+// Run on that board the same day, and it passed: the coil fired, the field
+// followed the board through the earth's, 1036 reads. A second entry into the
+// same screen did not, and the two faults it exposed are fixed above -- the
+// self-test no longer waits for a DRDY the part has stopped producing, and the
+// measurement configuration is established from a soft reset instead of
+// written on top of whatever the previous run left. That fix has not itself
+// been back on silicon. See BACKLOG.md.
+
+// Rev. C section 9.2.1, page 14: "Register 00H stores the chip ID. The default
+// value is 80H." One byte, and the only fixed thing in the map -- which makes
+// it a weak signature on its own, so it is read twice through
+// live_test_read_id8 and nothing is written until it agrees with itself.
+#define QMC_REG_CHIPID 0x00
+#define QMC_CHIPID     0x80
+
+// Rev. C Table 14 and Table 15, page 14: 01H..06H are X/Y/Z as LSB then MSB,
+// "16-bit data width in 2's complement". Read as one six-byte burst.
+#define QMC_REG_XOUT_LSB 0x01
+#define QMC_DATA_LEN     6
+
+// Rev. C section 9.2.2 and Table 16, page 14: status register 09H, bit 0 DRDY
+// "0: no new data, 1: new data is ready", bit 1 OVFL "set high when either axis
+// code output exceeds the range of [-30000,30000] LSB". Both are "reset to 0
+// after this bit is read", so one read of 09H consumes both flags and the data
+// registers must be read before asking again.
+#define QMC_REG_STATUS 0x09
+#define QMC_ST_DRDY    0x01
+#define QMC_ST_OVFL    0x02
+
+// Rev. C Table 17 and Table 18, page 15 and 16. Control register 1 at 0AH holds
+// OSR2<7:6>, OSR1<5:4>, ODR<3:2> and MODE<1:0>; control register 2 at 0BH holds
+// SOFT_RST<7>, SELF_TEST<6>, RNG<3:2> and SET/RESET MODE<1:0>.
+#define QMC_REG_CTRL1 0x0A
+#define QMC_REG_CTRL2 0x0B
+
+// The datasheet's own worked examples, quoted whole rather than assembled from
+// bit fields -- a byte that the manufacturer has written down and a byte that
+// happens to have the right bits in it are not the same kind of evidence.
+//
+// Rev. C section 7.2, page 11, "Continuous Mode Setup Example":
+//   Write Register 29H by 0x06 (Define the sign for X Y and Z axis)
+//   Write Register 0BH by 0x08 (Define Set/Reset mode, with Set/Reset On,
+//                               Field Range 8Guass)
+//   Write Register 0AH by 0xC3 (set continuous mode)
+#define QMC_REG_SIGN       0x29
+#define QMC_SIGN_VALUE     0x06
+#define QMC_CTRL2_RUN      0x08
+#define QMC_CTRL1_CONT     0xC3
+// Rev. C section 7.3, page 11, "Self-test Example": continuous mode is entered
+// with 0x03 and no 0BH write at all, so the range stays at its reset value.
+#define QMC_CTRL1_SELFRUN  0x03
+// Rev. C section 7.3: "Write Register 0BH by 0x40 (enter self-test function)".
+// Table 18: SELF_TEST is "1: self_test enable, auto clear after the data is
+// updated", and section 6.2.3 adds that the self-test "can only be enabled in
+// Continuous Mode and enters in Suspend Mode after the data is updated".
+#define QMC_CTRL2_SELFTEST 0x40
+// Rev. C section 7.6, page 11, "Soft Reset Example: Write Register 0BH by
+// 0x80", and Table 18: "1: Soft reset, restore default value of all registers".
+// One write undoes the sign register, both control registers and the mode --
+// which is why parking this part needs no bookkeeping about what was changed.
+#define QMC_CTRL2_SOFTRST  0x80
+// Rev. C section 7.4: "Suspend Mode Example: Write Register 0AH by 0x00".
+#define QMC_CTRL1_SUSPEND  0x00
+
+// Rev. C section 7.3: "Waiting 5 millisecond until measurement ends" between
+// arming the self-test and reading the second sample. Ten is double it, and the
+// only cost of being generous here is ten milliseconds once per run.
+#define QMC_SELFTEST_MS 10
+
+// Rev. C Table 17, page 15: ODR is bits 3:2 of the byte section 7.2 writes to
+// 0AH, and 0xC3 selects 10 Hz -- one new sample every hundred milliseconds.
+// Reading faster than that re-reads the sample already on the screen, and
+// publishing it again drives the display, and anything watching the USB screen
+// stream, at whatever rate the I2C bus happens to run at rather than at the
+// rate the part measures. So the loop waits a period between samples.
+#define QMC_SAMPLE_PERIOD_MS 100
+
+// Rev. C Table 2, page 8: sensitivity is 1000 LSB/G at the +/-30 G range and
+// 3750 LSB/G at +/-8 G. The self-test runs at the reset range because the
+// datasheet's example does; the measurement phase runs at +/-8 G because its
+// example does, and because four times the counts per gauss is four times the
+// evidence when the whole signal is the earth.
+#define QMC_LSB_PER_G_RESET 1000
+#define QMC_LSB_PER_G_RUN   3750
+
+// One gauss is a hundred microtesla, and microtesla is what the heading shows:
+// the earth reads about 50 of them, which is a number somebody can sanity-check
+// against the AK09911 test on the same bench.
+#define QMC_UT_PER_G 100.0f
+
+// Rev. C Table 2, page 8, "Field Resolution, standard deviation": 2 mGauss on
+// X and Y, 3 mGauss on Z. At the reset range's 1000 LSB/G that is 2, 2 and 3
+// counts of noise, so these are three sigma.
+//
+// This is a floor, not the specification. Section 9.2.3 says the self-test
+// "generat[es] a difference in the 3 axis' value" and that the "user should
+// record the value before and after the self-test and compare with threshold
+// value" -- and then publishes no threshold, anywhere in the document. So this
+// test cannot check the size of the deflection against what QST expects, and it
+// does not pretend to: it checks that a deflection happened at all, on every
+// axis, by a margin the part's own published noise cannot produce. A canned
+// register or a die that ignores bit 6 of 0BH gives zero. A working part gives
+// far more than nine counts, and if some part somewhere does not, the honest
+// fix is to obtain the threshold from QST rather than to lower these.
+#define QMC_SELFTEST_MIN_XY 6
+#define QMC_SELFTEST_MIN_Z  9
+
+// ponytail: derived from the datasheet rather than measured, which is exactly
+// the footing that made the AK09911 threshold wrong the first time -- so here
+// is the arithmetic, to be checked against a still part before it is trusted.
+//
+// The earth's field is 0.25 to 0.65 gauss depending on where you stand. At the
+// +/-8 G range's 3750 LSB/G that is 937 counts at the weakest place on earth,
+// and turning a board exactly end over end swings one axis by twice the
+// component along it -- so 1875 counts is the worst-case ceiling, not the
+// expectation. Three hundred is sixteen per cent of that ceiling, and forty
+// times the 7.5 counts of noise the same table implies at this range.
+//
+// The lesson from live_ak09911.c applies here and has not been paid yet:
+// measure the still board first. A threshold means nothing until the noise
+// floor under it is known, and this one has never been compared to one.
+#define QMC_MOVE_COUNTS 300
+#define QMC_MOVE_AXES   2
+
+// Two independent things, and neither implies the other: the part's own coil
+// deflects all three channels, and the field those channels report afterwards
+// follows the board through the earth's. A canned answer fails the second, a
+// dead channel fails the first.
+#define QMC_PROOF_STEPS 2
+
+// Continuous mode "runs all the time without sleep time" (section 6.2.3), so a
+// sample is never far away. Poll at 20 ms and give up after 500, which is
+// twenty-five polls -- long enough that a slow part is waited for, short enough
+// that a stopped one is noticed.
+#define QMC_POLL_MS           20
+#define QMC_SAMPLE_TIMEOUT_MS 500
+
+typedef struct {
+    int32_t min;
+    int32_t max;
+} QmcAxisRange;
+
+typedef enum {
+    QmcSampleOk,
+    QmcSampleOverflow, // past +/-30000 LSB: not a small reading, not a reading
+    QmcSampleFailed, // the bus failed, or nothing became ready in time
+} QmcSampleResult;
+
+static void qmc_delay(const volatile bool* stop, uint32_t ms) {
+    while(ms && !*stop) {
+        uint32_t chunk = ms > 40 ? 40 : ms;
+        furi_delay_ms(chunk);
+        ms -= chunk;
+    }
+}
+
+// Section 7.4's Suspend Mode example, used as the first step of every
+// configuration here. Section 9.2.3: "Suspend Mode should be added in the
+// middle of mode shifting between Continuous Mode, Single Mode and Normal
+// Mode." So the mode the next write starts from is established rather than
+// inherited from whatever the last pass left behind.
+//
+// This is not tidiness. On silicon the first run of this test passed and the
+// second did not, because the second began on a part still carrying the first
+// run's state. Section 7.6's soft reset was tried here first and is worse for
+// the job: it does more, but the datasheet gives no settling time for it
+// anywhere, and a configuration written into a part that is still resetting is
+// the same fault wearing a different hat. One write to 0AH needs no such
+// guess.
+static bool qmc_suspend(const LiveTestI2c* i2c, uint8_t addr7) {
+    return i2c->write_reg(addr7, QMC_REG_CTRL1, QMC_CTRL1_SUSPEND, LIVE_TEST_TIMEOUT_MS);
+}
+
+static LiveTestIdResult qmc_identify(const LiveTestI2c* i2c, uint8_t addr7) {
+    uint8_t id = 0;
+    if(!live_test_read_id8(i2c, addr7, QMC_REG_CHIPID, &id))
+        return live_test_id_unreadable(i2c, addr7);
+    return id == QMC_CHIPID ? LiveTestIdMatch : LiveTestIdMismatch;
+}
+
+// The six data bytes, assembled. Table 15 has them LSB register first then MSB
+// for each axis, "16-bit data width in 2's complement". Getting that backwards
+// produces numbers that look entirely plausible and are not.
+static bool qmc_read_data(const LiveTestI2c* i2c, uint8_t addr7, int32_t out[3]) {
+    uint8_t buf[QMC_DATA_LEN] = {0};
+    if(!i2c->read_mem(addr7, QMC_REG_XOUT_LSB, buf, sizeof(buf), LIVE_TEST_TIMEOUT_MS))
+        return false;
+    for(uint8_t axis = 0; axis < 3; axis++) {
+        out[axis] = (int16_t)((uint16_t)buf[axis * 2] | ((uint16_t)buf[axis * 2 + 1] << 8));
+    }
+    return true;
+}
+
+// One measurement: wait for DRDY in 09H, then read the six data bytes. The
+// status read is what clears both flags, so it happens once per attempt and its
+// result is carried out rather than asked for again.
+//
+// An overflowed sample is reported as such and its bytes are never returned.
+// Printing them would be printing a number the part did not stand behind, and
+// past 30000 LSB the axis has run out of range rather than measured anything.
+static QmcSampleResult qmc_read_sample(
+    const LiveTestI2c* i2c,
+    uint8_t addr7,
+    const volatile bool* stop,
+    int32_t out[3]) {
+    for(uint32_t waited = 0; waited < QMC_SAMPLE_TIMEOUT_MS && !*stop; waited += QMC_POLL_MS) {
+        uint8_t status = 0;
+        if(!i2c->read_reg(addr7, QMC_REG_STATUS, &status, LIVE_TEST_TIMEOUT_MS))
+            return QmcSampleFailed;
+
+        if(!(status & QMC_ST_DRDY)) {
+            qmc_delay(stop, QMC_POLL_MS);
+            continue;
+        }
+        if(status & QMC_ST_OVFL) return QmcSampleOverflow;
+
+        if(!qmc_read_data(i2c, addr7, out)) return QmcSampleFailed;
+        return QmcSampleOk;
+    }
+    return QmcSampleFailed;
+}
+
+// The datasheet's section 7.3 in order, with the two reads it asks for. The
+// deltas it defines are (x1-x2), (y2-y1) and (z2-z1) -- written with different
+// signs per axis because the internal coil pushes X one way and Y and Z the
+// other. Only the size of each is checked here; see QMC_SELFTEST_MIN_XY for why
+// the direction is not.
+static bool qmc_self_test(
+    const LiveTestI2c* i2c,
+    uint8_t addr7,
+    const volatile bool* stop,
+    int32_t delta[3]) {
+    if(!qmc_suspend(i2c, addr7)) return false;
+    if(!i2c->write_reg(addr7, QMC_REG_SIGN, QMC_SIGN_VALUE, LIVE_TEST_TIMEOUT_MS)) return false;
+    if(!i2c->write_reg(addr7, QMC_REG_CTRL1, QMC_CTRL1_SELFRUN, LIVE_TEST_TIMEOUT_MS))
+        return false;
+
+    int32_t before[3] = {0};
+    if(qmc_read_sample(i2c, addr7, stop, before) != QmcSampleOk) return false;
+
+    if(!i2c->write_reg(addr7, QMC_REG_CTRL2, QMC_CTRL2_SELFTEST, LIVE_TEST_TIMEOUT_MS))
+        return false;
+    qmc_delay(stop, QMC_SELFTEST_MS);
+
+    // Section 7.3 waits and then reads, with no second look at 09H: "Waiting 5
+    // millisecond until measurement ends / Read data Register 01H ~ 06H".
+    // Section 6.2.3 says why that is not an oversight -- the self-test "can
+    // only be enabled in Continuous Mode and enters in Suspend Mode after the
+    // data is updated", so a part that has finished is a part that has stopped,
+    // and DRDY is a flag on a sample that is not coming. Waiting for it here is
+    // what made the second run on silicon report "No self-test" from a part
+    // that had just done one.
+    int32_t after[3] = {0};
+    if(!qmc_read_data(i2c, addr7, after)) return false;
+
+    delta[0] = before[0] - after[0];
+    delta[1] = after[1] - before[1];
+    delta[2] = after[2] - before[2];
+    return true;
+}
+
+static bool qmc_self_test_passed(const int32_t delta[3]) {
+    const int32_t x = delta[0] < 0 ? -delta[0] : delta[0];
+    const int32_t y = delta[1] < 0 ? -delta[1] : delta[1];
+    const int32_t z = delta[2] < 0 ? -delta[2] : delta[2];
+    return x >= QMC_SELFTEST_MIN_XY && y >= QMC_SELFTEST_MIN_XY && z >= QMC_SELFTEST_MIN_Z;
+}
+
+static void qmc_run(const LiveTestEnv* env) {
+    const uint8_t addr7 = env->addr7;
+    const volatile bool* stop = env->stop;
+    const LiveTestI2c* i2c = env->i2c;
+    const LiveTestPublish publish = env->publish;
+    void* const ctx = env->ctx;
+
+    while(!*stop) {
+        LiveTestState st;
+        memset(&st, 0, sizeof(st));
+        st.phase = LiveTestPhaseStarting;
+        snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Reading the chip ID");
+        publish(ctx, &st);
+
+        const LiveTestIdResult id_seen = qmc_identify(i2c, addr7);
+        if(id_seen != LiveTestIdMatch) {
+            memset(&st, 0, sizeof(st));
+            st.phase = id_seen == LiveTestIdMismatch ? LiveTestPhaseWrongChip : LiveTestPhaseLost;
+            if(id_seen == LiveTestIdMismatch) {
+                // The likely case by some distance. A GY-271 board can carry an
+                // HMC5883L, a QMC5883L or this, and only this one sits at 0x2C.
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "0x%02X answers, but not", addr7);
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "the way a QMC5883P does.");
+            } else {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It replied, then stopped.");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Check 3V3 and the wires.");
+            }
+            publish(ctx, &st);
+            qmc_delay(
+                stop,
+                id_seen == LiveTestIdMismatch ? LIVE_TEST_WRONG_CHIP_RETRY_MS :
+                                                LIVE_TEST_RETRY_MS);
+            continue;
+        }
+
+        // Identified. From here every path has written something, so every path
+        // out of this loop body soft-resets the part -- including the ones where
+        // a write was not acknowledged, because a write that was not
+        // acknowledged may still have landed.
+
+        // --- Self-test --------------------------------------------------
+        memset(&st, 0, sizeof(st));
+        st.phase = LiveTestPhaseStarting;
+        st.progress_max = QMC_PROOF_STEPS;
+        snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Firing the test coil");
+        snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Hold it still.");
+        publish(ctx, &st);
+
+        int32_t delta[3] = {0};
+        const bool self_ran = qmc_self_test(i2c, addr7, stop, delta);
+        const bool self_ok = self_ran && qmc_self_test_passed(delta);
+
+        // --- Continuous measurement -------------------------------------
+        // Section 6.2.3 has the self-test drop the part into Suspend Mode when
+        // it finishes -- but only when it finishes, and the self-test above is
+        // allowed to fail halfway with 0BH already written. So the mode is
+        // established rather than assumed, and then section 7.2's example
+        // follows, all three writes, in its order.
+        const bool measuring =
+            qmc_suspend(i2c, addr7) &&
+            i2c->write_reg(addr7, QMC_REG_SIGN, QMC_SIGN_VALUE, LIVE_TEST_TIMEOUT_MS) &&
+            i2c->write_reg(addr7, QMC_REG_CTRL2, QMC_CTRL2_RUN, LIVE_TEST_TIMEOUT_MS) &&
+            i2c->write_reg(addr7, QMC_REG_CTRL1, QMC_CTRL1_CONT, LIVE_TEST_TIMEOUT_MS);
+
+        QmcAxisRange range[3];
+        for(uint8_t axis = 0; axis < 3; axis++) {
+            range[axis] = (QmcAxisRange){.min = INT32_MAX, .max = INT32_MIN};
+        }
+        const uint32_t started = furi_get_tick();
+        uint32_t samples = 0;
+        uint16_t overflows = 0;
+        uint8_t errors = 0;
+        bool passed = false;
+
+        while(measuring && !passed && !*stop && errors < 3) {
+            int32_t raw[3] = {0};
+            const QmcSampleResult got = qmc_read_sample(i2c, addr7, stop, raw);
+            if(got == QmcSampleOverflow) {
+                // A magnet against the case. Not a fault and not an error
+                // budget item, but it does have to reach the screen: OVFL
+                // clears on the read that saw it, so without a publish here the
+                // display would simply stop moving with no reason given.
+                overflows++;
+                memset(&st, 0, sizeof(st));
+                st.phase = LiveTestPhaseRunning;
+                st.progress = self_ok ? 1 : 0;
+                st.progress_max = QMC_PROOF_STEPS;
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Too strong - back it off");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Saturated x%u", (unsigned)overflows);
+                publish(ctx, &st);
+                qmc_delay(stop, QMC_SAMPLE_PERIOD_MS);
+                continue;
+            }
+            if(got != QmcSampleOk) {
+                errors++;
+                continue;
+            }
+            errors = 0;
+            samples++;
+
+            uint8_t moved = 0;
+            for(uint8_t axis = 0; axis < 3; axis++) {
+                if(raw[axis] < range[axis].min) range[axis].min = raw[axis];
+                if(raw[axis] > range[axis].max) range[axis].max = raw[axis];
+                if(range[axis].max - range[axis].min >= QMC_MOVE_COUNTS) moved++;
+            }
+            passed = self_ok && moved >= QMC_MOVE_AXES;
+            if(passed) break; // publish it after the part is parked, not before
+
+            const float field =
+                QMC_UT_PER_G *
+                sqrtf((float)raw[0] * raw[0] + (float)raw[1] * raw[1] + (float)raw[2] * raw[2]) /
+                QMC_LSB_PER_G_RUN;
+
+            memset(&st, 0, sizeof(st));
+            st.phase = LiveTestPhaseRunning;
+            st.value = field;
+            st.progress = self_ok ? 1 : 0;
+            st.progress_max = QMC_PROOF_STEPS;
+            snprintf(st.heading, sizeof(st.heading), "%u", (unsigned)field);
+            snprintf(st.unit, sizeof(st.unit), "uT");
+            // Two lines, because a heading and progress boxes leave room for
+            // exactly two. Line 0 is the instruction and carries its own
+            // feedback; line 1 is what the coil said, which is the half the
+            // user cannot see happening.
+            snprintf(
+                st.lines[0], LIVE_TEST_LINE_LEN, "Turn it over - %u/%u axes", moved, QMC_MOVE_AXES);
+            snprintf(
+                st.lines[1],
+                LIVE_TEST_LINE_LEN,
+                self_ran ? (self_ok ? "Coil OK         %lus" : "Coil weak       %lus") :
+                           "No self-test    %lus",
+                (unsigned long)((furi_get_tick() - started) / furi_ms_to_ticks(1000)));
+            publish(ctx, &st);
+            qmc_delay(stop, QMC_SAMPLE_PERIOD_MS);
+        }
+
+        // --- Park it ----------------------------------------------------
+        // One write puts everything back: section 7.6's soft reset restores the
+        // default value of all registers, which includes the sign register this
+        // test wrote and the Suspend Mode the part powers up in. Done before
+        // anything is published so the pass chime lands after the last
+        // measurement rather than during one -- this is a magnetometer and the
+        // speaker is a centimetre away.
+        const bool parked =
+            i2c->write_reg(addr7, QMC_REG_CTRL2, QMC_CTRL2_SOFTRST, LIVE_TEST_TIMEOUT_MS);
+
+        if(*stop) break;
+
+        memset(&st, 0, sizeof(st));
+        st.progress_max = QMC_PROOF_STEPS;
+        if(passed) {
+            st.phase = LiveTestPhasePassed;
+            st.progress = QMC_PROOF_STEPS;
+            snprintf(st.heading, sizeof(st.heading), "%lu", (unsigned long)samples);
+            snprintf(st.unit, sizeof(st.unit), "reads");
+            if(parked) {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "The coil fired and the");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "field followed you.");
+            } else {
+                snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "Passed, but the part was");
+                snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "left running. Repower.");
+            }
+            publish(ctx, &st);
+            // Nothing is being measured and nothing is configured; this is a
+            // plain wait for Back.
+            while(!*stop)
+                qmc_delay(stop, QMC_POLL_MS);
+            break;
+        }
+
+        st.phase = LiveTestPhaseLost;
+        st.progress = self_ok ? 1 : 0;
+        if(!measuring) {
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It will not start");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "measuring. Check 3V3.");
+        } else {
+            snprintf(st.lines[0], LIVE_TEST_LINE_LEN, "It stopped answering.");
+            snprintf(st.lines[1], LIVE_TEST_LINE_LEN, "Check 3V3 and the wires.");
+        }
+        publish(ctx, &st);
+        qmc_delay(stop, LIVE_TEST_RETRY_MS);
+    }
+}
+
+const LiveTest live_test_qmc5883p = {
+    .chip = "QMC5883P",
+    .title = "QMC5883P test",
+    .offer = "Turn it through a field",
+    .addrs = {0x2C},
+    .run = qmc_run,
+    .draw = NULL,
+};

--- a/non_catalog_apps/fake_chip_detector/live_qmc5883p.h
+++ b/non_catalog_apps/fake_chip_detector/live_qmc5883p.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "live_test.h"
+
+extern const LiveTest live_test_qmc5883p;

--- a/non_catalog_apps/fake_chip_detector/live_test.c
+++ b/non_catalog_apps/fake_chip_detector/live_test.c
@@ -10,6 +10,8 @@
 #include "live_ds3231.h"
 #include "live_mlx90614.h"
 #include "live_mpu6050.h"
+#include "live_qmc5883l.h"
+#include "live_qmc5883p.h"
 #include "live_sht.h"
 #include "live_ssd1306.h"
 #include "live_vl6180x.h"
@@ -50,6 +52,8 @@ static const LiveTest* const live_tests[] = {
     &live_test_mpu6050,
     &live_test_mpu6500,
     &live_test_mpu9250,
+    &live_test_qmc5883l,
+    &live_test_qmc5883p,
     &live_test_sht,
     &live_test_ssd1306,
     &live_test_vl6180x,


### PR DESCRIPTION
Thank you for merging the app and for the UI patch — that fix is already in `dev` and is already the code in this diff, so this update carries it rather than reverting it. The upstream commit keeps your authorship.

This brings the copy here from **0.10 to 0.13**.

### The QMC5883P live test, fixed twice

It passed on a GY-271 board the first time and failed on the second entry into the same screen, which turned up three real faults:

- **It waited for a data-ready flag the part stops producing.** The self-test enters Suspend Mode when it finishes, so DRDY was a flag on a sample that was never coming.
- **It configured on top of the previous run's mode.** Now established with Suspend, which is what the datasheet asks for in the middle of a mode shift — a soft reset was tried first and is worse, because the document gives no settling time for one anywhere.
- **It published a frame per bus round trip.** The part produces a sample ten times a second; the loop read and redrew as fast as I²C would go, so most reads returned the number already on the screen and every one of them drove the display — and anything watching the screen over USB — again. It waits a sample period between reads now. That one was found because screenshots over RPC stopped working during the test.

It has since passed twice on the bench, most recently reading 27 µT — inside the earth's 25 to 65.

### New: a QMC5883L live test

The die a board silkscreened GY-271 most often carries. The field must move by 240 counts on two different axes while the board is turned, and that is its only claim: this part has no self-test bit — its second control register holds a soft reset, a pointer-roll bit and an interrupt enable and nothing else — so there is no coil firing underneath the movement and the screen does not pretend there is. Every sequence in it is QST's own worked example, cited to the datasheet by section and page.

**Not run on hardware.** No QMC5883L has been on this bench at all; the board that prompted the work carries a P.

Sixteen live tests now, thirteen of which have never met the chip they were written for.

### Also

The standalone `README.md` this pack carries is restored — the app's own README upstream is a stub pointing one directory up, which does not exist here.

Source: https://github.com/hleserg/flipper-fake-chip-detector/releases/tag/v0.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5mqN8Ut59ZvKWYYZEHczJ